### PR TITLE
Patchmanager 0.3.2

### DIFF
--- a/plugin_template/swinfo.json
+++ b/plugin_template/swinfo.json
@@ -5,7 +5,7 @@
   "name": "Patch Manager",
   "description": "A mod for generic patching needs similar to KSP 1's Module Manager.",
   "source": "https://github.com/KSP2Community/PatchManager",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "version_check": "https://raw.githubusercontent.com/KSP2Community/PatchManager/main/plugin_template/swinfo.json",
   "ksp2_version": {
     "min": "0.1.5",

--- a/src/PatchManager.Core/CoreModule.cs
+++ b/src/PatchManager.Core/CoreModule.cs
@@ -72,24 +72,24 @@ public class CoreModule : BaseModule
         if (!isValid)
         {
             _wasCacheInvalidated = true;
-            SpaceWarp.API.Loading.Loading.AddGeneralLoadingAction(
-                () => new GenericFlowAction("Patch Manager: Creating New Assets", PatchingManager.CreateNewAssets));
-            SpaceWarp.API.Loading.Loading.AddGeneralLoadingAction(
-                () => new GenericFlowAction("Patch Manager: Rebuilding Cache", PatchingManager.RebuildAllCache));
+            SpaceWarp.API.Loading.Loading.GeneralLoadingActions.Insert(0,() => new GenericFlowAction("Patch Manager: Creating New Assets", PatchingManager.CreateNewAssets));
+            SpaceWarp.API.Loading.Loading.GeneralLoadingActions.Insert(1,() => new GenericFlowAction("Patch Manager: Rebuilding Cache", PatchingManager.RebuildAllCache));
+            SpaceWarp.API.Loading.Loading.GeneralLoadingActions.Insert(2, () => new GenericFlowAction("Patch Manager: Registering Resource Locator", RegisterResourceLocator));
+            // SpaceWarp.API.Loading.Loading.AddGeneralLoadingAction(
+            //     () => new GenericFlowAction("Patch Manager: Creating New Assets", PatchingManager.CreateNewAssets));
+            // SpaceWarp.API.Loading.Loading.AddGeneralLoadingAction(
+            //     () => new GenericFlowAction("Patch Manager: Rebuilding Cache", PatchingManager.RebuildAllCache));
         }
     }
-
     /// <summary>
     /// Registers the provider and locator for cached assets.
     /// </summary>
-    public override void Load()
+    private void RegisterResourceLocator(Action resolve, Action<string> reject)
     {
-        
-        Logging.LogInfo("Registering resource locator");
         Addressables.ResourceManager.ResourceProviders.Add(new ArchiveResourceProvider());
         Locators.Register(new ArchiveResourceLocator());
+        resolve();
     }
-
     /// <inheritdoc />
     public override VisualElement GetDetails()
     {

--- a/src/PatchManager.Core/CoreModule.cs
+++ b/src/PatchManager.Core/CoreModule.cs
@@ -80,6 +80,10 @@ public class CoreModule : BaseModule
             // SpaceWarp.API.Loading.Loading.AddGeneralLoadingAction(
             //     () => new GenericFlowAction("Patch Manager: Rebuilding Cache", PatchingManager.RebuildAllCache));
         }
+        else
+        {
+            SpaceWarp.API.Loading.Loading.GeneralLoadingActions.Insert(0, () => new GenericFlowAction("Patch Manager: Registering Resource Locator", RegisterResourceLocator));
+        }
     }
     /// <summary>
     /// Registers the provider and locator for cached assets.

--- a/src/PatchManager.Core/PatchManager.Core.csproj
+++ b/src/PatchManager.Core/PatchManager.Core.csproj
@@ -2,8 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <!-- References -->
     <ItemGroup Label="NuGet package references">
+        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
         <PackageReference Include="KerbalSpaceProgram2.GameLibs" Version="0.1.5" PrivateAssets="all" />
-        <PackageReference Include="SpaceWarp" Version="1.5.2" PrivateAssets="all" />
+        <PackageReference Include="SpaceWarp" Version="1.5.2" PrivateAssets="all" Publicize="true"/>
     </ItemGroup>
     <ItemGroup Label="Project references">
         <ProjectReference Include="$(SolutionDir)/src/PatchManager.SassyPatching/PatchManager.SassyPatching.csproj" Private="false" />

--- a/src/PatchManager.Parts/Patchers/UpdateSavedVesselPartDefinitions.cs
+++ b/src/PatchManager.Parts/Patchers/UpdateSavedVesselPartDefinitions.cs
@@ -21,6 +21,8 @@ public class UpdateSavedVesselPartDefinitions : FlowAction
             resolve();
             return;
         }
+        List<int> toRemove = new();
+        int idx = 0;
         foreach (var vessel in _loadGameData.SavedGame.Vessels)
         {
             // Lets change only a few things
@@ -29,6 +31,12 @@ public class UpdateSavedVesselPartDefinitions : FlowAction
             {
                 var name = part.partName;
                 var def = GameManager.Instance.Game.Parts.Get(name);
+                if (def == null)
+                {
+                    Logging.LogWarning($"Invalid part {name} found on vessel {vessel.AssemblyDefinition.assemblyName}, removing vessel from save file\n");
+                    toRemove.Add(idx);
+                    break;
+                }
                 for (var i = part.PartModulesState.Count - 1; i >= 0; i--)
                 {
                     var i2 = i;
@@ -59,7 +67,16 @@ public class UpdateSavedVesselPartDefinitions : FlowAction
                     }
                 }
             }
+            idx += 1;
         }
+
+        toRemove.Reverse();
+        var vesselList = _loadGameData.SavedGame.Vessels.ToList();
+        foreach (var removal in toRemove)
+        {
+            vesselList.RemoveAt(removal);
+        }
+        _loadGameData.SavedGame.Vessels = vesselList.ToArray();
         resolve();
     }
 }


### PR DESCRIPTION
This is a simple fix that makes patch managers loading actions always be the first ones run (uses unstable parts of spacewarp so will likely have to be maintained on updates to spacewarp, or have the feature added into spacewarp later :3)