### PR TITLE
High-level Campaign packs implementation

### DIFF
--- a/Runtime/CampaignPacks.meta
+++ b/Runtime/CampaignPacks.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9c1e0b465a5d4d858308fca1b8676f5e
+timeCreated: 1780215600

--- a/Runtime/CampaignPacks/CampaignPackDefinitions.cs
+++ b/Runtime/CampaignPacks/CampaignPackDefinitions.cs
@@ -1,0 +1,240 @@
+using System.Collections.Generic;
+
+namespace PatchManager.CampaignPacks
+{
+    /// <summary>
+    /// Runtime JSON-facing representation of a campaign pack.
+    /// </summary>
+    public sealed class CampaignPackDefinition
+    {
+        /// <summary>
+        /// Stable campaign pack identifier used by other campaign pack definitions and extensions.
+        /// </summary>
+        public string Id = string.Empty;
+
+        /// <summary>
+        /// Localization key used for the player-facing campaign pack name.
+        /// </summary>
+        public string NameLocKey = string.Empty;
+
+        /// <summary>
+        /// Localization key used for the player-facing campaign pack description.
+        /// </summary>
+        public string DescriptionLocKey = string.Empty;
+
+        /// <summary>
+        /// Addressable or data key of the galaxy definition used by this campaign pack.
+        /// </summary>
+        public string GalaxyDefinitionKey = string.Empty;
+
+        /// <summary>
+        /// Optional identifier of the tech tree set referenced by this campaign pack.
+        /// </summary>
+        public string TechTreeSetId = string.Empty;
+
+        /// <summary>
+        /// Optional identifier of the mission set referenced by this campaign pack.
+        /// </summary>
+        public string MissionSetId = string.Empty;
+
+        /// <summary>
+        /// Optional identifier of the science set referenced by this campaign pack.
+        /// </summary>
+        public string ScienceSetId = string.Empty;
+    }
+
+    /// <summary>
+    /// Runtime JSON-facing representation of a tech tree set.
+    /// </summary>
+    public sealed class TechTreeSetDefinition
+    {
+        /// <summary>
+        /// Stable tech tree set identifier.
+        /// </summary>
+        public string Id = string.Empty;
+
+        /// <summary>
+        /// Tech tree node identifiers included by this set before extensions are applied.
+        /// </summary>
+        public List<string> TechNodeIds = new();
+    }
+
+    /// <summary>
+    /// Runtime JSON-facing representation of a mission set.
+    /// </summary>
+    public sealed class MissionSetDefinition
+    {
+        /// <summary>
+        /// Stable mission set identifier.
+        /// </summary>
+        public string Id = string.Empty;
+
+        /// <summary>
+        /// Mission identifiers included by this set before extensions are applied.
+        /// </summary>
+        public List<string> MissionIds = new();
+    }
+
+    /// <summary>
+    /// Runtime JSON-facing representation of a science set.
+    /// </summary>
+    public sealed class ScienceSetDefinition
+    {
+        /// <summary>
+        /// Stable science set identifier.
+        /// </summary>
+        public string Id = string.Empty;
+
+        /// <summary>
+        /// Science experiment identifiers included by this set before extensions are applied.
+        /// </summary>
+        public List<string> ExperimentIds = new();
+
+        /// <summary>
+        /// Science region identifiers included by this set before extensions are applied.
+        /// </summary>
+        public List<string> ScienceRegionIds = new();
+
+        /// <summary>
+        /// Discoverable identifiers included by this set before extensions are applied.
+        /// </summary>
+        public List<string> DiscoverableIds = new();
+    }
+
+    /// <summary>
+    /// Runtime JSON-facing representation of campaign pack extension add/remove operations.
+    /// </summary>
+    public sealed class CampaignPackExtensionDefinition
+    {
+        /// <summary>
+        /// Stable campaign pack extension identifier.
+        /// </summary>
+        public string Id = string.Empty;
+
+        /// <summary>
+        /// Optional campaign pack identifier this extension applies to.
+        /// </summary>
+        public string TargetCampaignPackId = string.Empty;
+
+        /// <summary>
+        /// Optional tech tree set identifier this extension applies to.
+        /// </summary>
+        public string TargetTechTreeSetId = string.Empty;
+
+        /// <summary>
+        /// Optional mission set identifier this extension applies to.
+        /// </summary>
+        public string TargetMissionSetId = string.Empty;
+
+        /// <summary>
+        /// Optional science set identifier this extension applies to.
+        /// </summary>
+        public string TargetScienceSetId = string.Empty;
+
+        /// <summary>
+        /// Tech tree node identifiers added to matching campaign packs.
+        /// </summary>
+        public List<string> AddTechNodeIds = new();
+
+        /// <summary>
+        /// Tech tree node identifiers removed from matching campaign packs after additions are applied.
+        /// </summary>
+        public List<string> RemoveTechNodeIds = new();
+
+        /// <summary>
+        /// Mission identifiers added to matching campaign packs.
+        /// </summary>
+        public List<string> AddMissionIds = new();
+
+        /// <summary>
+        /// Mission identifiers removed from matching campaign packs after additions are applied.
+        /// </summary>
+        public List<string> RemoveMissionIds = new();
+
+        /// <summary>
+        /// Science experiment identifiers added to matching campaign packs.
+        /// </summary>
+        public List<string> AddExperimentIds = new();
+
+        /// <summary>
+        /// Science experiment identifiers removed from matching campaign packs after additions are applied.
+        /// </summary>
+        public List<string> RemoveExperimentIds = new();
+
+        /// <summary>
+        /// Science region identifiers added to matching campaign packs.
+        /// </summary>
+        public List<string> AddScienceRegionIds = new();
+
+        /// <summary>
+        /// Science region identifiers removed from matching campaign packs after additions are applied.
+        /// </summary>
+        public List<string> RemoveScienceRegionIds = new();
+
+        /// <summary>
+        /// Discoverable identifiers added to matching campaign packs.
+        /// </summary>
+        public List<string> AddDiscoverableIds = new();
+
+        /// <summary>
+        /// Discoverable identifiers removed from matching campaign packs after additions are applied.
+        /// </summary>
+        public List<string> RemoveDiscoverableIds = new();
+    }
+
+    /// <summary>
+    /// Fully resolved campaign pack contents after base sets and matching extensions are applied.
+    /// </summary>
+    public sealed class EffectiveCampaignPack
+    {
+        /// <summary>
+        /// Identifier of the campaign pack that was resolved.
+        /// </summary>
+        public string CampaignPackId = string.Empty;
+
+        /// <summary>
+        /// Localization key used for the resolved campaign pack name.
+        /// </summary>
+        public string NameLocKey = string.Empty;
+
+        /// <summary>
+        /// Localization key used for the resolved campaign pack description.
+        /// </summary>
+        public string DescriptionLocKey = string.Empty;
+
+        /// <summary>
+        /// Galaxy definition key selected by the resolved campaign pack.
+        /// </summary>
+        public string GalaxyDefinitionKey = string.Empty;
+
+        /// <summary>
+        /// Effective tech tree node identifiers after base sets and extensions are applied.
+        /// </summary>
+        public List<string> TechNodeIds = new();
+
+        /// <summary>
+        /// Effective mission identifiers after base sets and extensions are applied.
+        /// </summary>
+        public List<string> MissionIds = new();
+
+        /// <summary>
+        /// Effective science experiment identifiers after base sets and extensions are applied.
+        /// </summary>
+        public List<string> ExperimentIds = new();
+
+        /// <summary>
+        /// Effective science region identifiers after base sets and extensions are applied.
+        /// </summary>
+        public List<string> ScienceRegionIds = new();
+
+        /// <summary>
+        /// Effective discoverable identifiers after base sets and extensions are applied.
+        /// </summary>
+        public List<string> DiscoverableIds = new();
+
+        /// <summary>
+        /// Identifiers of extensions that matched and were applied while resolving this campaign pack.
+        /// </summary>
+        public List<string> AppliedExtensionIds = new();
+    }
+}

--- a/Runtime/CampaignPacks/CampaignPackDefinitions.cs.meta
+++ b/Runtime/CampaignPacks/CampaignPackDefinitions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 34a397478f6248aeb44f2bcaa77d0f61
+timeCreated: 1780215600

--- a/Runtime/CampaignPacks/CampaignPackRuntimeCatalog.cs
+++ b/Runtime/CampaignPacks/CampaignPackRuntimeCatalog.cs
@@ -1,0 +1,394 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PatchManager.CampaignPacks
+{
+    /// <summary>
+    /// In-memory runtime catalog for loaded campaign pack definitions and resolved previews.
+    /// </summary>
+    public sealed class CampaignPackRuntimeCatalog
+    {
+        private readonly Dictionary<string, CampaignPackDefinition> _packs = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, TechTreeSetDefinition> _techTreeSets = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, MissionSetDefinition> _missionSets = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, ScienceSetDefinition> _scienceSets = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, CampaignPackExtensionDefinition> _extensions = new(StringComparer.Ordinal);
+        private readonly List<string> _issues = new();
+
+        /// <summary>
+        /// Loaded campaign pack definitions keyed by campaign pack id.
+        /// </summary>
+        public IReadOnlyDictionary<string, CampaignPackDefinition> Packs => _packs;
+
+        /// <summary>
+        /// Loaded tech tree set definitions keyed by set id.
+        /// </summary>
+        public IReadOnlyDictionary<string, TechTreeSetDefinition> TechTreeSets => _techTreeSets;
+
+        /// <summary>
+        /// Loaded mission set definitions keyed by set id.
+        /// </summary>
+        public IReadOnlyDictionary<string, MissionSetDefinition> MissionSets => _missionSets;
+
+        /// <summary>
+        /// Loaded science set definitions keyed by set id.
+        /// </summary>
+        public IReadOnlyDictionary<string, ScienceSetDefinition> ScienceSets => _scienceSets;
+
+        /// <summary>
+        /// Loaded campaign pack extension definitions keyed by extension id.
+        /// </summary>
+        public IReadOnlyDictionary<string, CampaignPackExtensionDefinition> Extensions => _extensions;
+
+        /// <summary>
+        /// Load and validation issues discovered while building the catalog.
+        /// </summary>
+        public IReadOnlyList<string> Issues => _issues;
+
+        /// <summary>
+        /// Adds a load-time issue to the catalog diagnostics.
+        /// </summary>
+        /// <param name="issue">Human-readable issue text.</param>
+        public void AddLoadIssue(string issue)
+        {
+            _issues.Add($"[Load] {issue}");
+        }
+
+        /// <summary>
+        /// Removes all loaded definitions and validation issues.
+        /// </summary>
+        public void Clear()
+        {
+            _packs.Clear();
+            _techTreeSets.Clear();
+            _missionSets.Clear();
+            _scienceSets.Clear();
+            _extensions.Clear();
+            _issues.Clear();
+        }
+
+        /// <summary>
+        /// Adds a campaign pack definition to the catalog.
+        /// </summary>
+        /// <param name="definition">Campaign pack definition to add.</param>
+        /// <param name="sourceName">Optional source asset name used for diagnostics.</param>
+        public void AddPack(CampaignPackDefinition definition, string sourceName = "")
+        {
+            AddDefinition(_packs, definition?.Id, definition, "Campaign pack", sourceName);
+        }
+
+        /// <summary>
+        /// Adds a tech tree set definition to the catalog.
+        /// </summary>
+        /// <param name="definition">Tech tree set definition to add.</param>
+        /// <param name="sourceName">Optional source asset name used for diagnostics.</param>
+        public void AddTechTreeSet(TechTreeSetDefinition definition, string sourceName = "")
+        {
+            AddDefinition(_techTreeSets, definition?.Id, definition, "Tech tree set", sourceName);
+        }
+
+        /// <summary>
+        /// Adds a mission set definition to the catalog.
+        /// </summary>
+        /// <param name="definition">Mission set definition to add.</param>
+        /// <param name="sourceName">Optional source asset name used for diagnostics.</param>
+        public void AddMissionSet(MissionSetDefinition definition, string sourceName = "")
+        {
+            AddDefinition(_missionSets, definition?.Id, definition, "Mission set", sourceName);
+        }
+
+        /// <summary>
+        /// Adds a science set definition to the catalog.
+        /// </summary>
+        /// <param name="definition">Science set definition to add.</param>
+        /// <param name="sourceName">Optional source asset name used for diagnostics.</param>
+        public void AddScienceSet(ScienceSetDefinition definition, string sourceName = "")
+        {
+            AddDefinition(_scienceSets, definition?.Id, definition, "Science set", sourceName);
+        }
+
+        /// <summary>
+        /// Adds a campaign pack extension definition to the catalog.
+        /// </summary>
+        /// <param name="definition">Campaign pack extension definition to add.</param>
+        /// <param name="sourceName">Optional source asset name used for diagnostics.</param>
+        public void AddExtension(CampaignPackExtensionDefinition definition, string sourceName = "")
+        {
+            AddDefinition(_extensions, definition?.Id, definition, "Campaign pack extension", sourceName);
+        }
+
+        /// <summary>
+        /// Resolves the effective contents for a loaded campaign pack.
+        /// </summary>
+        /// <param name="packId">Campaign pack identifier.</param>
+        /// <returns>Resolved contents, or <c>null</c> when the pack is unknown.</returns>
+        public EffectiveCampaignPack Resolve(string packId)
+        {
+            if (string.IsNullOrWhiteSpace(packId) || !_packs.TryGetValue(packId, out var pack))
+            {
+                return null;
+            }
+
+            var result = new EffectiveCampaignPack
+            {
+                CampaignPackId = pack.Id,
+                NameLocKey = pack.NameLocKey,
+                DescriptionLocKey = pack.DescriptionLocKey,
+                GalaxyDefinitionKey = pack.GalaxyDefinitionKey
+            };
+
+            if (!string.IsNullOrWhiteSpace(pack.TechTreeSetId) && _techTreeSets.TryGetValue(pack.TechTreeSetId, out var techTreeSet))
+            {
+                result.TechNodeIds.AddRange(CopyDistinct(techTreeSet.TechNodeIds));
+            }
+
+            if (!string.IsNullOrWhiteSpace(pack.MissionSetId) && _missionSets.TryGetValue(pack.MissionSetId, out var missionSet))
+            {
+                result.MissionIds.AddRange(CopyDistinct(missionSet.MissionIds));
+            }
+
+            if (!string.IsNullOrWhiteSpace(pack.ScienceSetId) && _scienceSets.TryGetValue(pack.ScienceSetId, out var scienceSet))
+            {
+                result.ExperimentIds.AddRange(CopyDistinct(scienceSet.ExperimentIds));
+                result.ScienceRegionIds.AddRange(CopyDistinct(scienceSet.ScienceRegionIds));
+                result.DiscoverableIds.AddRange(CopyDistinct(scienceSet.DiscoverableIds));
+            }
+
+            var matching = GetMatchingExtensions(pack).OrderBy(e => e.Id, StringComparer.Ordinal).ToList();
+            foreach (var extension in matching)
+            {
+                AddRangeUnique(result.TechNodeIds, extension.AddTechNodeIds);
+                AddRangeUnique(result.MissionIds, extension.AddMissionIds);
+                AddRangeUnique(result.ExperimentIds, extension.AddExperimentIds);
+                AddRangeUnique(result.ScienceRegionIds, extension.AddScienceRegionIds);
+                AddRangeUnique(result.DiscoverableIds, extension.AddDiscoverableIds);
+                if (!string.IsNullOrWhiteSpace(extension.Id))
+                {
+                    result.AppliedExtensionIds.Add(extension.Id);
+                }
+            }
+
+            foreach (var extension in matching)
+            {
+                RemoveAll(result.TechNodeIds, extension.RemoveTechNodeIds);
+                RemoveAll(result.MissionIds, extension.RemoveMissionIds);
+                RemoveAll(result.ExperimentIds, extension.RemoveExperimentIds);
+                RemoveAll(result.ScienceRegionIds, extension.RemoveScienceRegionIds);
+                RemoveAll(result.DiscoverableIds, extension.RemoveDiscoverableIds);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Rebuilds runtime validation issues for all loaded definitions.
+        /// </summary>
+        public void Validate()
+        {
+            _issues.RemoveAll(issue => issue.StartsWith("[Validation]", StringComparison.Ordinal));
+
+            foreach (var pack in _packs.Values)
+            {
+                if (string.IsNullOrWhiteSpace(pack.GalaxyDefinitionKey))
+                {
+                    AddValidationIssue($"Campaign pack '{pack.Id}' has no galaxy definition key.");
+                }
+
+                AddMissingReference(pack.Id, "tech tree set", pack.TechTreeSetId, _techTreeSets);
+                AddMissingReference(pack.Id, "mission set", pack.MissionSetId, _missionSets);
+                AddMissingReference(pack.Id, "science set", pack.ScienceSetId, _scienceSets);
+            }
+
+            foreach (var extension in _extensions.Values)
+            {
+                var hasTarget = !string.IsNullOrWhiteSpace(extension.TargetCampaignPackId) ||
+                    !string.IsNullOrWhiteSpace(extension.TargetTechTreeSetId) ||
+                    !string.IsNullOrWhiteSpace(extension.TargetMissionSetId) ||
+                    !string.IsNullOrWhiteSpace(extension.TargetScienceSetId);
+
+                if (!hasTarget)
+                {
+                    AddValidationIssue($"Campaign pack extension '{extension.Id}' does not target a pack or set.");
+                }
+                else if (!_packs.Values.Any(pack => TargetsPack(extension, pack)))
+                {
+                    AddValidationIssue($"Campaign pack extension '{extension.Id}' does not match any loaded campaign pack.");
+                }
+
+                AddConflictIssue(extension.Id, "tech node", extension.AddTechNodeIds, extension.RemoveTechNodeIds);
+                AddConflictIssue(extension.Id, "mission", extension.AddMissionIds, extension.RemoveMissionIds);
+                AddConflictIssue(extension.Id, "science experiment", extension.AddExperimentIds, extension.RemoveExperimentIds);
+                AddConflictIssue(extension.Id, "science region", extension.AddScienceRegionIds, extension.RemoveScienceRegionIds);
+                AddConflictIssue(extension.Id, "discoverable", extension.AddDiscoverableIds, extension.RemoveDiscoverableIds);
+            }
+        }
+
+        /// <summary>
+        /// Resolves all loaded campaign packs in stable id order.
+        /// </summary>
+        /// <returns>Resolved campaign pack previews.</returns>
+        public IReadOnlyList<EffectiveCampaignPack> ResolveAll()
+        {
+            return _packs.Keys
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .Select(Resolve)
+                .OfType<EffectiveCampaignPack>()
+                .ToList();
+        }
+
+        /// <summary>
+        /// Builds a human-readable summary of loaded definitions, resolved contents, and diagnostics.
+        /// </summary>
+        /// <returns>Summary text suitable for logs and Patch Manager detail UI.</returns>
+        public string BuildSummaryText()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Campaign Packs:");
+            sb.AppendLine($"Packs: {_packs.Count}");
+            sb.AppendLine($"Tech tree sets: {_techTreeSets.Count}");
+            sb.AppendLine($"Mission sets: {_missionSets.Count}");
+            sb.AppendLine($"Science sets: {_scienceSets.Count}");
+            sb.AppendLine($"Extensions: {_extensions.Count}");
+
+            var effectivePacks = ResolveAll();
+            foreach (var pack in effectivePacks)
+            {
+                sb.AppendLine("");
+                sb.AppendLine($"- {pack.CampaignPackId}");
+                sb.AppendLine($"  Galaxy: {ValueOrNone(pack.GalaxyDefinitionKey)}");
+                AppendIdList(sb, "Tech nodes", pack.TechNodeIds);
+                AppendIdList(sb, "Missions", pack.MissionIds);
+                AppendIdList(sb, "Experiments", pack.ExperimentIds);
+                AppendIdList(sb, "Science regions", pack.ScienceRegionIds);
+                AppendIdList(sb, "Discoverables", pack.DiscoverableIds);
+                AppendIdList(sb, "Extensions", pack.AppliedExtensionIds);
+            }
+
+            if (_issues.Count > 0)
+            {
+                sb.AppendLine("");
+                sb.AppendLine("Issues:");
+                foreach (var issue in _issues)
+                {
+                    sb.AppendLine($"- {issue}");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private void AddDefinition<T>(Dictionary<string, T> target, string id, T definition, string kind, string sourceName)
+            where T : class
+        {
+            if (definition == null)
+            {
+                AddLoadIssue($"{kind} from '{ValueOrNone(sourceName)}' could not be read.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                AddLoadIssue($"{kind} from '{ValueOrNone(sourceName)}' has no id.");
+                return;
+            }
+
+            if (target.ContainsKey(id))
+            {
+                AddLoadIssue($"{kind} id '{id}' is duplicated; keeping the first loaded definition.");
+                return;
+            }
+
+            target[id] = definition;
+        }
+
+        private IEnumerable<CampaignPackExtensionDefinition> GetMatchingExtensions(CampaignPackDefinition pack)
+        {
+            return _extensions.Values.Where(extension => TargetsPack(extension, pack));
+        }
+
+        private static bool TargetsPack(CampaignPackExtensionDefinition extension, CampaignPackDefinition pack)
+        {
+            return Matches(extension.TargetCampaignPackId, pack.Id) ||
+                Matches(extension.TargetTechTreeSetId, pack.TechTreeSetId) ||
+                Matches(extension.TargetMissionSetId, pack.MissionSetId) ||
+                Matches(extension.TargetScienceSetId, pack.ScienceSetId);
+        }
+
+        private static bool Matches(string target, string actual)
+        {
+            return !string.IsNullOrWhiteSpace(target) &&
+                !string.IsNullOrWhiteSpace(actual) &&
+                string.Equals(target, actual, StringComparison.Ordinal);
+        }
+
+        private void AddMissingReference<T>(string packId, string kind, string id, Dictionary<string, T> known)
+        {
+            if (!string.IsNullOrWhiteSpace(id) && !known.ContainsKey(id))
+            {
+                AddValidationIssue($"Campaign pack '{packId}' references missing {kind} '{id}'.");
+            }
+        }
+
+        private void AddConflictIssue(string extensionId, string kind, IEnumerable<string> additions, IEnumerable<string> removals)
+        {
+            var addSet = new HashSet<string>((additions ?? Enumerable.Empty<string>()).Where(id => !string.IsNullOrWhiteSpace(id)));
+            foreach (var id in (removals ?? Enumerable.Empty<string>()).Where(id => !string.IsNullOrWhiteSpace(id)).Distinct())
+            {
+                if (addSet.Contains(id))
+                {
+                    AddValidationIssue($"Campaign pack extension '{extensionId}' both adds and removes {kind} '{id}'. Removal will win.");
+                }
+            }
+        }
+
+        private void AddValidationIssue(string issue)
+        {
+            _issues.Add($"[Validation] {issue}");
+        }
+
+        private static IEnumerable<string> CopyDistinct(IEnumerable<string> values)
+        {
+            return (values ?? Enumerable.Empty<string>()).Where(value => !string.IsNullOrWhiteSpace(value)).Distinct();
+        }
+
+        private static void AddRangeUnique(List<string> target, IEnumerable<string> values)
+        {
+            if (values == null) return;
+            foreach (var value in values)
+            {
+                if (string.IsNullOrWhiteSpace(value) || target.Contains(value)) continue;
+                target.Add(value);
+            }
+        }
+
+        private static void RemoveAll(List<string> target, IEnumerable<string> values)
+        {
+            if (values == null) return;
+            var removals = new HashSet<string>(values.Where(value => !string.IsNullOrWhiteSpace(value)));
+            target.RemoveAll(removals.Contains);
+        }
+
+        private static string ValueOrNone(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "<none>" : value;
+        }
+
+        private static void AppendIdList(StringBuilder sb, string label, IReadOnlyCollection<string> ids)
+        {
+            sb.AppendLine($"  {label} ({ids.Count}):");
+
+            if (ids.Count == 0)
+            {
+                sb.AppendLine("    <none>");
+                return;
+            }
+
+            foreach (var id in ids)
+            {
+                sb.AppendLine($"    - {id}");
+            }
+        }
+    }
+}

--- a/Runtime/CampaignPacks/CampaignPackRuntimeCatalog.cs
+++ b/Runtime/CampaignPacks/CampaignPackRuntimeCatalog.cs
@@ -19,6 +19,8 @@ namespace PatchManager.CampaignPacks
 
         /// <summary>
         /// Loaded campaign pack definitions keyed by campaign pack id.
+        /// Prefer <see cref="GetCampaignPackIds"/>, <see cref="TryGetCampaignPackDefinition"/>, and
+        /// <see cref="Resolve"/> for gameplay-facing queries.
         /// </summary>
         public IReadOnlyDictionary<string, CampaignPackDefinition> Packs => _packs;
 
@@ -46,6 +48,44 @@ namespace PatchManager.CampaignPacks
         /// Load and validation issues discovered while building the catalog.
         /// </summary>
         public IReadOnlyList<string> Issues => _issues;
+
+        /// <summary>
+        /// Gets the loaded campaign pack identifiers in stable id order.
+        /// </summary>
+        /// <returns>Loaded campaign pack identifiers.</returns>
+        public IReadOnlyList<string> GetCampaignPackIds()
+        {
+            return _packs.Keys
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Checks whether a campaign pack definition is loaded.
+        /// </summary>
+        /// <param name="packId">Campaign pack identifier to check.</param>
+        /// <returns><see langword="true"/> when the catalog contains the requested campaign pack.</returns>
+        public bool ContainsCampaignPack(string packId)
+        {
+            return !string.IsNullOrWhiteSpace(packId) && _packs.ContainsKey(packId);
+        }
+
+        /// <summary>
+        /// Attempts to fetch the raw campaign pack definition for editor/debug style inspection.
+        /// </summary>
+        /// <param name="packId">Campaign pack identifier to fetch.</param>
+        /// <param name="definition">Loaded campaign pack definition when found; otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> when the definition was found.</returns>
+        public bool TryGetCampaignPackDefinition(string packId, out CampaignPackDefinition definition)
+        {
+            if (!string.IsNullOrWhiteSpace(packId) && _packs.TryGetValue(packId, out definition))
+            {
+                return true;
+            }
+
+            definition = null;
+            return false;
+        }
 
         /// <summary>
         /// Adds a load-time issue to the catalog diagnostics.
@@ -183,6 +223,18 @@ namespace PatchManager.CampaignPacks
         }
 
         /// <summary>
+        /// Attempts to resolve the effective contents for a loaded campaign pack.
+        /// </summary>
+        /// <param name="packId">Campaign pack identifier.</param>
+        /// <param name="effectivePack">Resolved contents when found; otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> when the campaign pack exists and was resolved.</returns>
+        public bool TryResolve(string packId, out EffectiveCampaignPack effectivePack)
+        {
+            effectivePack = Resolve(packId);
+            return effectivePack != null;
+        }
+
+        /// <summary>
         /// Rebuilds runtime validation issues for all loaded definitions.
         /// </summary>
         public void Validate()
@@ -231,8 +283,7 @@ namespace PatchManager.CampaignPacks
         /// <returns>Resolved campaign pack previews.</returns>
         public IReadOnlyList<EffectiveCampaignPack> ResolveAll()
         {
-            return _packs.Keys
-                .OrderBy(id => id, StringComparer.Ordinal)
+            return GetCampaignPackIds()
                 .Select(Resolve)
                 .OfType<EffectiveCampaignPack>()
                 .ToList();

--- a/Runtime/CampaignPacks/CampaignPackRuntimeCatalog.cs.meta
+++ b/Runtime/CampaignPacks/CampaignPackRuntimeCatalog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 70e3392c4d0d42cd987bc47db44667c5

--- a/Runtime/CampaignPacks/CampaignPacksModule.cs
+++ b/Runtime/CampaignPacks/CampaignPacksModule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using KSP.Game;
 using Newtonsoft.Json;
 using PatchManager.Shared;
@@ -44,6 +45,55 @@ namespace PatchManager.CampaignPacks
         /// Runtime catalog populated from baked campaign pack JSON assets.
         /// </summary>
         public static CampaignPackRuntimeCatalog Catalog { get; } = new();
+
+        /// <summary>
+        /// Gets the loaded campaign pack identifiers in stable id order.
+        /// </summary>
+        /// <returns>Loaded campaign pack identifiers.</returns>
+        public static IReadOnlyList<string> GetCampaignPackIds()
+        {
+            return Catalog.GetCampaignPackIds();
+        }
+
+        /// <summary>
+        /// Checks whether a campaign pack definition is loaded.
+        /// </summary>
+        /// <param name="packId">Campaign pack identifier to check.</param>
+        /// <returns><see langword="true"/> when the catalog contains the requested campaign pack.</returns>
+        public static bool ContainsCampaignPack(string packId)
+        {
+            return Catalog.ContainsCampaignPack(packId);
+        }
+
+        /// <summary>
+        /// Resolves the effective contents for a loaded campaign pack.
+        /// </summary>
+        /// <param name="packId">Campaign pack identifier.</param>
+        /// <returns>Resolved contents, or <see langword="null"/> when the pack is unknown.</returns>
+        public static EffectiveCampaignPack Resolve(string packId)
+        {
+            return Catalog.Resolve(packId);
+        }
+
+        /// <summary>
+        /// Attempts to resolve the effective contents for a loaded campaign pack.
+        /// </summary>
+        /// <param name="packId">Campaign pack identifier.</param>
+        /// <param name="effectivePack">Resolved contents when found; otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> when the campaign pack exists and was resolved.</returns>
+        public static bool TryResolve(string packId, out EffectiveCampaignPack effectivePack)
+        {
+            return Catalog.TryResolve(packId, out effectivePack);
+        }
+
+        /// <summary>
+        /// Resolves all loaded campaign packs in stable id order.
+        /// </summary>
+        /// <returns>Resolved campaign pack previews.</returns>
+        public static IReadOnlyList<EffectiveCampaignPack> ResolveAll()
+        {
+            return Catalog.ResolveAll();
+        }
 
         private int _pendingLoads;
         private bool _loadStarted;

--- a/Runtime/CampaignPacks/CampaignPacksModule.cs
+++ b/Runtime/CampaignPacks/CampaignPacksModule.cs
@@ -1,0 +1,179 @@
+using System;
+using KSP.Game;
+using Newtonsoft.Json;
+using PatchManager.Shared;
+using PatchManager.Shared.Modules;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.UIElements;
+
+namespace PatchManager.CampaignPacks
+{
+    /// <summary>
+    /// Loads baked campaign pack JSON and exposes a read-only runtime inspection summary.
+    /// </summary>
+    public sealed class CampaignPacksModule : BaseModule
+    {
+        /// <summary>
+        /// Addressables label used for baked campaign pack JSON assets.
+        /// </summary>
+        public const string CampaignPacksLabel = "campaign_packs";
+
+        /// <summary>
+        /// Addressables label used for baked campaign pack tech tree set JSON assets.
+        /// </summary>
+        public const string TechTreeSetsLabel = "campaign_pack_tech_tree_sets";
+
+        /// <summary>
+        /// Addressables label used for baked campaign pack mission set JSON assets.
+        /// </summary>
+        public const string MissionSetsLabel = "campaign_pack_mission_sets";
+
+        /// <summary>
+        /// Addressables label used for baked campaign pack science set JSON assets.
+        /// </summary>
+        public const string ScienceSetsLabel = "campaign_pack_science_sets";
+
+        /// <summary>
+        /// Addressables label used for baked campaign pack extension JSON assets.
+        /// </summary>
+        public const string ExtensionsLabel = "campaign_pack_extensions";
+
+        /// <summary>
+        /// Runtime catalog populated from baked campaign pack JSON assets.
+        /// </summary>
+        public static CampaignPackRuntimeCatalog Catalog { get; } = new();
+
+        private int _pendingLoads;
+        private bool _loadStarted;
+        private TextElement _detailsText;
+
+        /// <inheritdoc />
+        public override void Load()
+        {
+            Catalog.Clear();
+            _pendingLoads = 5;
+            _loadStarted = true;
+
+            LoadDefinitions<CampaignPackDefinition>(
+                CampaignPacksLabel,
+                (definition, sourceName) => Catalog.AddPack(definition, sourceName));
+            LoadDefinitions<TechTreeSetDefinition>(
+                TechTreeSetsLabel,
+                (definition, sourceName) => Catalog.AddTechTreeSet(definition, sourceName));
+            LoadDefinitions<MissionSetDefinition>(
+                MissionSetsLabel,
+                (definition, sourceName) => Catalog.AddMissionSet(definition, sourceName));
+            LoadDefinitions<ScienceSetDefinition>(
+                ScienceSetsLabel,
+                (definition, sourceName) => Catalog.AddScienceSet(definition, sourceName));
+            LoadDefinitions<CampaignPackExtensionDefinition>(
+                ExtensionsLabel,
+                (definition, sourceName) => Catalog.AddExtension(definition, sourceName));
+        }
+
+        /// <inheritdoc />
+        public override VisualElement GetDetails()
+        {
+            var foldout = new Foldout
+            {
+                text = "PatchManager.CampaignPacks",
+                visible = true,
+                style =
+                {
+                    display = DisplayStyle.Flex
+                }
+            };
+
+            _detailsText = new TextElement
+            {
+                visible = true,
+                style =
+                {
+                    display = DisplayStyle.Flex,
+                    whiteSpace = WhiteSpace.Normal
+                }
+            };
+            RefreshDetailsText();
+            foldout.Add(_detailsText);
+            return foldout;
+        }
+
+        private void LoadDefinitions<T>(string label, Action<T, string> addDefinition)
+            where T : class
+        {
+            var handle = GameManager.Instance.Assets.LoadAssetsAsync<TextAsset>(
+                label,
+                asset => ImportDefinition(asset, addDefinition));
+
+            handle.Completed += result =>
+            {
+                if (result.Status != AsyncOperationStatus.Succeeded)
+                {
+                    Logging.LogWarning($"[Campaign Packs] Failed to load addressable label '{label}'.");
+                    Catalog.AddLoadIssue($"Failed to load addressable label '{label}'.");
+                }
+
+                Addressables.Release(handle);
+                OnLabelLoadFinished();
+            };
+        }
+
+        private static void ImportDefinition<T>(TextAsset asset, Action<T, string> addDefinition)
+            where T : class
+        {
+            if (!asset)
+            {
+                return;
+            }
+
+            try
+            {
+                var definition = JsonConvert.DeserializeObject<T>(asset.text);
+                addDefinition(definition, asset.name);
+            }
+            catch (Exception ex)
+            {
+                Logging.LogWarning($"[Campaign Packs] Failed to parse '{asset.name}': {ex.Message}");
+                Catalog.AddLoadIssue($"Failed to parse '{asset.name}': {ex.Message}");
+            }
+        }
+
+        private void OnLabelLoadFinished()
+        {
+            _pendingLoads--;
+            if (_pendingLoads > 0)
+            {
+                RefreshDetailsText();
+                return;
+            }
+
+            Catalog.Validate();
+            LogSummary();
+            RefreshDetailsText();
+        }
+
+        private static void LogSummary()
+        {
+            Logging.LogInfo($"[Campaign Packs]\n{Catalog.BuildSummaryText()}");
+            foreach (var issue in Catalog.Issues)
+            {
+                Logging.LogWarning($"[Campaign Packs] {issue}");
+            }
+        }
+
+        private void RefreshDetailsText()
+        {
+            if (_detailsText == null)
+            {
+                return;
+            }
+
+            var loading = _loadStarted && _pendingLoads > 0
+                ? $"Loading campaign pack labels... {_pendingLoads} remaining.\n\n"
+                : string.Empty;
+            _detailsText.text = loading + Catalog.BuildSummaryText();
+        }
+    }
+}

--- a/Runtime/CampaignPacks/CampaignPacksModule.cs.meta
+++ b/Runtime/CampaignPacks/CampaignPacksModule.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 60a24681846d4179989ac79d4afe1de0
+timeCreated: 1780215600

--- a/Runtime/PatchManager.cs
+++ b/Runtime/PatchManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using PatchManager.CampaignPacks;
 using PatchManager.Core;
 using PatchManager.Generic;
 using PatchManager.LuaPatching;
@@ -39,6 +40,7 @@ namespace PatchManager
             ModuleManager.Register(typeof(ResourcesModule));
             ModuleManager.Register(typeof(ScienceModule));
             ModuleManager.Register(typeof(PlanetsModule));
+            ModuleManager.Register(typeof(CampaignPacksModule));
             Logging.Initialize(SWLogger);
             foreach (var module in ModuleManager.Modules)
             {


### PR DESCRIPTION
Campaign Packs could become the clean way to bundle a “way to play” without forcing every mod to own the whole game setup.

A pack can point at a galaxy, tech tree set, mission set, and science set, while extensions let other mods add or remove content without having to copy the whole thing. So one mod could add a planet pack, another could add missions for it, another could rebalance the tech tree, and they can all layer onto the same campaign setup instead of creating a bunch of incompatible forks.

For players, this could just become a simple choice when starting a save: stock-style Redux campaign, KSP1-inspired progression, a planet-pack campaign, a hard-mode career, a science-only setup, etc.

For modders, the main benefit is that they can make focused content. They do not need to rebuild a full campaign definition just to add five missions or a few tech nodes. They can create a small extension that targets an existing pack or set, and the system resolves the final playable campaign from all the pieces.

---

Adds a runtime-side prototype for Campaign Packs, building on the editor authoring tools from [KSP2Redux/SDK#3](https://github.com/KSP2Redux/SDK/pull/3).

This is intentionally a fairly high-level and modular implementation. The goal is not to lock in every runtime decision yet, but to create a small bridge between the baked authoring JSON and the game/runtime side so we can inspect how the system behaves and iterate from there. If parts of the structure do not fit what we want later, they should be easy to add, remove, or reshape.

Adds runtime JSON definitions for:

- Campaign packs
- Tech tree sets
- Mission sets
- Science sets
- Campaign pack extensions

Adds a runtime catalog that can:

- Load the baked JSON definitions
- Track loaded packs, sets, and extensions
- Resolve effective campaign pack contents
- Apply base sets first, then extensions, then removals
- Report validation/load issues
- Produce a readable summary for debugging

Adds a new Patch Manager module:

- Loads campaign pack JSON from addressable labels
- Logs the resolved campaign pack summary
- Exposes a `PatchManager.CampaignPacks` details foldout for quick in-game inspection

## Notes

The Campaign Packs does not do anything yet. For now, this is just the safe runtime inspection layer: author assets in the SDK tools, bake them to JSON, load them at runtime, and inspect the resolved result.

The intent is to keep the system flexible while we figure out the exact shape Campaign Packs should take.