### PR TITLE
Prefab patching

### DIFF
--- a/Editor/PrefabPatchPlayModeCleanup.cs
+++ b/Editor/PrefabPatchPlayModeCleanup.cs
@@ -1,0 +1,20 @@
+using PatchManager.PrefabPatching;
+using UnityEditor;
+
+namespace PatchManager.Editor;
+
+[InitializeOnLoad]
+internal static class PrefabPatchPlayModeCleanup
+{
+    static PrefabPatchPlayModeCleanup()
+    {
+        EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+        EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+    }
+
+    private static void OnPlayModeStateChanged(PlayModeStateChange state)
+    {
+        if (state == PlayModeStateChange.ExitingPlayMode)
+            PrefabPatchRuntime.ReleaseSessionResources();
+    }
+}

--- a/Editor/PrefabPatchPlayModeCleanup.cs.meta
+++ b/Editor/PrefabPatchPlayModeCleanup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eb817b87703b6924b85e5d1609007969

--- a/PREFAB_PATCHING.md
+++ b/PREFAB_PATCHING.md
@@ -113,12 +113,12 @@ for tools/tests; normal mods call `Register`. `GameObject(path)` and
 any generic operation method; `SetComponent` is shorthand for the common
 scalar-component case.
 
-Bundle/CAB names, hashes, path IDs, and structural fingerprints are compiler
-metadata, not handwritten C#/Lua inputs. Visual manifests retain that stronger
-source-build validation. Imperative patches intentionally resolve their
-Addressables key and named hierarchy path at runtime. Duplicate child names at
-one hierarchy level are rejected as ambiguous rather than resolved
-arbitrarily.
+Visual, C#, and Lua manifests all identify the stock prefab by its Addressables
+key. Compiled visual manifests additionally retain a structural fingerprint
+and sibling-index runtime locators, but do not serialize catalog, bundle, CAB,
+path-ID, or full structural-description metadata. Imperative patches resolve
+named hierarchy paths at runtime. Duplicate child names at one hierarchy level
+are rejected as ambiguous rather than resolved arbitrarily.
 
 Patch-owned targets use the local owning patch name plus stable
 object/component ID. An explicit `other-mod:patch-name` is used only when

--- a/PREFAB_PATCHING.md
+++ b/PREFAB_PATCHING.md
@@ -113,6 +113,12 @@ Lua uses `PM:Prefab`. Tables use the camel-case names from the public JSON
 schema; empty Lua tables are normalized to empty arrays where the model expects
 a collection.
 
+Write `sourcePathId` values as quoted decimal strings when copying canonical
+identities or stock targets into Lua. Unity path IDs are signed 64-bit integers,
+while Lua numbers cannot exactly represent every value in that range. Patch
+Manager accepts either form and converts decimal strings to `Int64` without
+losing precision.
+
 ```lua
 local patch = PM:Prefab("toolbar", targetIdentity)
     :Needs("some-required-mod")

--- a/PREFAB_PATCHING.md
+++ b/PREFAB_PATCHING.md
@@ -162,6 +162,9 @@ required patch.
 
 ## Runtime and compatibility behavior
 
+- Prefab discovery, plan-cache, ordering, diagnostics, and composition failures
+  are written as a `Prefab Patches` section in the existing
+  `pm_summary.log`; prefab updates preserve the ordinary JSON-patch summary.
 - Composition occurs once per resolved stock prefab and the effective prefab is
   cached for repeated provider requests.
 - Resolver ordering, required/conflicting mods and patches, and field conflicts

--- a/PREFAB_PATCHING.md
+++ b/PREFAB_PATCHING.md
@@ -1,0 +1,160 @@
+# Declarative prefab patches
+
+Patch Manager prefab patches modify stock Addressable prefabs before the game
+instantiates them. Visual prefab-variant authoring, C#, and Lua all generate the
+same versioned JSON manifest and use the same resolver, ordering rules, cache,
+and runtime composer.
+
+The schema is type-agnostic for Unity `Component` types. An added component is
+identified by its assembly-qualified CLR type and contains:
+
+- every serialized value, using Unity `SerializedProperty` paths;
+- every Unity object reference as a separate fixup;
+- a stable patch-local component ID.
+
+The runtime constructs all patch-owned objects and components beneath an
+inactive root, applies collection sizes and serialized values, and then resolves
+references. This permits references between sibling objects, between arbitrary
+components, into nested serialized arrays/lists, to stock prefab objects, and
+to mod or stock Addressables. It also prevents `OnEnable` from observing a
+partially hydrated effective prefab.
+
+The first implementation was never released. Schema 2 is therefore the only
+accepted schema; there is no schema-1 migration path. Recompile any local
+experimental manifests from their authoring variants.
+
+## Visual authoring
+
+In Redux SDK:
+
+1. Import the stock prefab with BundleKit's Linked Addressables Browser.
+2. Right-click the linked prefab and choose **Redux SDK > Create Prefab Patch
+   from Linked Prefab**.
+3. Edit the generated prefab variant normally.
+4. Add `PrefabPatchAuthoringObjectId` to every newly added GameObject and give
+   each one a stable ID.
+5. Save the variant. With auto-compile enabled, its `.prefabpatch.json` manifest
+   is rebuilt immediately.
+
+New `GameObject`, `RectTransform`, UGUI, TMP, game, and mod component types use
+the same general compiler. The compiler records the complete serialized
+component state; it does not select from a component whitelist. Local
+GameObject/component references are translated to patch-owned IDs. Linked game
+assets and mod-owned Addressables remain address references and are loaded
+before composition.
+
+## C# authoring
+
+Register C# patches before `PrefabPatchRuntime.CloseRegistration()`:
+
+```csharp
+using PatchManager.PrefabPatching;
+using UnityEngine;
+using UnityEngine.UI;
+
+var button = PrefabPatchComponentBuilder
+    .For<Button>("toolbar:button")
+    .Value("m_Interactable", PrefabPatchValue.FromBoolean(false))
+    .Reference(
+        "m_TargetGraphic",
+        PrefabPatchBuilder.TargetReference(
+            PrefabPatchBuilder.PatchComponent(
+                "my-mod:toolbar",
+                "toolbar:image"
+            ),
+            typeof(Graphic)
+        )
+    )
+    .Build();
+var image = PrefabPatchComponentBuilder
+    .For<Image>("toolbar:image")
+    .Build();
+
+new PrefabPatchBuilder("my-mod", "toolbar", targetIdentity, "1.0.0")
+    .AddObject(
+        "01-add-toolbar",
+        stockParentTarget,
+        new PrefabPatchObjectBuilder("toolbar", "Toolbar")
+            .Rect(
+                Vector2.zero,
+                Vector2.zero,
+                Vector2.zero,
+                new Vector2(320, 80),
+                new Vector2(0.5f, 0.5f)
+            )
+            .Component(image)
+            .Component(button)
+            .Build()
+    )
+    .Register();
+```
+
+`PrefabPatchBuilder` also exposes value/reference writes, active/suppress,
+add/remove component, ordering, dependency, conflict, and configuration-input
+methods. `PatchObject` and `PatchComponent` create stable targets for objects
+introduced by this or a required patch. Addressable references are created with
+`Addressable`.
+
+Operation order is the fluent call order. This is significant when a later
+operation targets an object or component introduced earlier in the same patch.
+
+## Lua authoring
+
+Lua uses `PM:Prefab`. Tables use the camel-case names from the public JSON
+schema; empty Lua tables are normalized to empty arrays where the model expects
+a collection.
+
+```lua
+local patch = PM:Prefab("toolbar", targetIdentity)
+    :Needs("some-required-mod")
+    :AddObject("01-add-toolbar", stockParent, {
+        objectId = "toolbar",
+        name = "Toolbar",
+        transformType = UnityRectTransformType,
+        active = true,
+        tag = "Untagged",
+        components = {
+            {
+                componentId = "toolbar:button",
+                componentType = UnityButtonType,
+                values = {
+                    {
+                        propertyPath = "m_Interactable",
+                        value = { kind = "Boolean", boolean = false }
+                    }
+                },
+                references = {}
+            }
+        },
+        children = {}
+    })
+
+patch:Register()
+```
+
+The returned builder supports `Early`, `Late`, `First`, `Last`, dependency and
+ordering methods, `Set`, `Reference`, `Active`, `Suppress`, `AddObject`,
+`AddComponent`, `RemoveComponent`, `Build`, and `Register`. `Build` is useful
+for tools/tests; normal mods call `Register`.
+
+Pure Lua/C# patches still need the stock prefab's canonical identity and
+structural fingerprint, plus canonical stock-object targets. Those values are
+source-build-specific safety data, not name-based hierarchy paths. They can be
+copied from a visual compiler manifest for the same linked prefab. Patch-owned
+targets only need the owning patch ID plus stable object/component ID.
+
+## Runtime and compatibility behavior
+
+- Composition occurs once per resolved stock prefab and the effective prefab is
+  cached for repeated provider requests.
+- Resolver ordering, required/conflicting mods and patches, and field conflicts
+  are identical for all three frontends.
+- The player loads Addressable references before applying the plan. Target
+  references are resolved locally after every object/component has been
+  created.
+- A missing CLR component type, missing Addressable, stale stock fingerprint,
+  invalid property path, or unknown project tag fails the patch with a precise
+  diagnostic instead of silently dropping data.
+- Patch manifests and mod-owned assets are distributable. Linked stock game
+  assets remain external references and are not copied into a mod build by the
+  prefab patch schema.

--- a/PREFAB_PATCHING.md
+++ b/PREFAB_PATCHING.md
@@ -53,47 +53,25 @@ before composition.
 
 ## C# authoring
 
-Register C# patches before `PrefabPatchRuntime.CloseRegistration()`:
+Register C# patches before `PrefabPatchRuntime.CloseRegistration()`. Handwritten
+patches target a stock Addressables key and select objects by their ordinary
+prefab hierarchy path:
 
 ```csharp
 using PatchManager.PrefabPatching;
 using PatchManager.CSharpPatching;
-using UnityEngine;
 using UnityEngine.UI;
 
-var button = PrefabPatchComponentBuilder
-    .For<Button>("toolbar:button")
-    .Value("m_Interactable", PrefabPatchValue.FromBoolean(false))
-    .Reference(
-        "m_TargetGraphic",
-        PrefabPatchBuilder.TargetReference(
-            PrefabPatchBuilder.PatchComponent(
-                "toolbar",
-                "toolbar:image"
-            ),
-            typeof(Graphic)
-        )
-    )
-    .Build();
-var image = PrefabPatchComponentBuilder
-    .For<Image>("toolbar:image")
-    .Build();
+var background = PrefabPatchBuilder.ComponentAt<Image>(
+    "KSP2UIWindow/Root/Window-App/Background"
+);
 
-Patching.Mod.PatchPrefab("toolbar", targetIdentity)
-    .AddObject(
-        "01-add-toolbar",
-        stockParentTarget,
-        new PrefabPatchObjectBuilder("toolbar", "Toolbar")
-            .Rect(
-                Vector2.zero,
-                Vector2.zero,
-                Vector2.zero,
-                new Vector2(320, 80),
-                new Vector2(0.5f, 0.5f)
-            )
-            .Component(image)
-            .Component(button)
-            .Build()
+Patching.Mod.PatchPrefab("toolbar", "SomeWindow.prefab")
+    .SetValue(
+        "tint-background",
+        background,
+        "m_Color.r",
+        PrefabPatchValue.FromFloat(0.25)
     )
     .Register();
 ```
@@ -113,36 +91,16 @@ Lua uses `PM:Prefab`. Tables use the camel-case names from the public JSON
 schema; empty Lua tables are normalized to empty arrays where the model expects
 a collection.
 
-Write `sourcePathId` values as quoted decimal strings when copying canonical
-identities or stock targets into Lua. Unity path IDs are signed 64-bit integers,
-while Lua numbers cannot exactly represent every value in that range. Patch
-Manager accepts either form and converts decimal strings to `Int64` without
-losing precision.
-
 ```lua
-local patch = PM:Prefab("toolbar", targetIdentity)
+local patch = PM:Prefab("toolbar", "SomeWindow.prefab")
     :Needs("some-required-mod")
-    :AddObject("01-add-toolbar", stockParent, {
-        objectId = "toolbar",
-        name = "Toolbar",
-        transformType = UnityRectTransformType,
-        active = true,
-        tag = "Untagged",
-        components = {
-            {
-                componentId = "toolbar:button",
-                componentType = UnityButtonType,
-                values = {
-                    {
-                        propertyPath = "m_Interactable",
-                        value = { kind = "Boolean", boolean = false }
-                    }
-                },
-                references = {}
-            }
-        },
-        children = {}
-    })
+    :SetComponent(
+        "tint-background",
+        "KSP2UIWindow/Root/Window-App/Background",
+        "UnityEngine.UI.Image",
+        "m_Color.r",
+        0.25
+    )
 
 patch:Register()
 ```
@@ -150,15 +108,21 @@ patch:Register()
 The returned builder supports `Early`, `Late`, `First`, `Last`, dependency and
 ordering methods, `Set`, `Reference`, `Active`, `Suppress`, `AddObject`,
 `AddComponent`, `RemoveComponent`, `Build`, and `Register`. `Build` is useful
-for tools/tests; normal mods call `Register`.
+for tools/tests; normal mods call `Register`. `GameObject(path)` and
+`Component(path, type, ordinal)` return key-first targets that can be passed to
+any generic operation method; `SetComponent` is shorthand for the common
+scalar-component case.
 
-Pure Lua/C# patches still need the stock prefab's canonical identity and
-structural fingerprint, plus canonical stock-object targets. Those values are
-source-build-specific safety data, not name-based hierarchy paths. They can be
-copied from a visual compiler manifest for the same linked prefab. Patch-owned
-targets only need the local owning patch name plus stable object/component ID.
-An explicit `other-mod:patch-name` is used only when targeting another mod's
-required patch.
+Bundle/CAB names, hashes, path IDs, and structural fingerprints are compiler
+metadata, not handwritten C#/Lua inputs. Visual manifests retain that stronger
+source-build validation. Imperative patches intentionally resolve their
+Addressables key and named hierarchy path at runtime. Duplicate child names at
+one hierarchy level are rejected as ambiguous rather than resolved
+arbitrarily.
+
+Patch-owned targets use the local owning patch name plus stable
+object/component ID. An explicit `other-mod:patch-name` is used only when
+targeting another mod's required patch.
 
 ## Runtime and compatibility behavior
 

--- a/PREFAB_PATCHING.md
+++ b/PREFAB_PATCHING.md
@@ -19,9 +19,17 @@ components, into nested serialized arrays/lists, to stock prefab objects, and
 to mod or stock Addressables. It also prevents `OnEnable` from observing a
 partially hydrated effective prefab.
 
-The first implementation was never released. Schema 2 is therefore the only
-accepted schema; there is no schema-1 migration path. Recompile any local
-experimental manifests from their authoring variants.
+This is still the initial prerelease schema (`schemaVersion: 1`,
+`composerVersion: 1`). There is no compatibility or migration layer. Recompile
+local experimental manifests from their authoring variants whenever the schema
+changes.
+
+Compiled JSON contains the local `patchName`, operations, dependencies, and
+target identity. It does not serialize a mod ID or mod version. In editor Play
+Mode, the owning Mod authoring asset supplies the ID. In a player, Patch
+Manager associates each manifest's Addressables catalog with the SpaceWarp
+descriptor that loaded it and uses that descriptor's `swinfo` ID. The
+fully-qualified `mod-id:patch-name` exists only in the resolved runtime model.
 
 ## Visual authoring
 
@@ -49,6 +57,7 @@ Register C# patches before `PrefabPatchRuntime.CloseRegistration()`:
 
 ```csharp
 using PatchManager.PrefabPatching;
+using PatchManager.CSharpPatching;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -59,7 +68,7 @@ var button = PrefabPatchComponentBuilder
         "m_TargetGraphic",
         PrefabPatchBuilder.TargetReference(
             PrefabPatchBuilder.PatchComponent(
-                "my-mod:toolbar",
+                "toolbar",
                 "toolbar:image"
             ),
             typeof(Graphic)
@@ -70,7 +79,7 @@ var image = PrefabPatchComponentBuilder
     .For<Image>("toolbar:image")
     .Build();
 
-new PrefabPatchBuilder("my-mod", "toolbar", targetIdentity, "1.0.0")
+Patching.Mod.PatchPrefab("toolbar", targetIdentity)
     .AddObject(
         "01-add-toolbar",
         stockParentTarget,
@@ -141,7 +150,9 @@ Pure Lua/C# patches still need the stock prefab's canonical identity and
 structural fingerprint, plus canonical stock-object targets. Those values are
 source-build-specific safety data, not name-based hierarchy paths. They can be
 copied from a visual compiler manifest for the same linked prefab. Patch-owned
-targets only need the owning patch ID plus stable object/component ID.
+targets only need the local owning patch name plus stable object/component ID.
+An explicit `other-mod:patch-name` is used only when targeting another mod's
+required patch.
 
 ## Runtime and compatibility behavior
 

--- a/PREFAB_PATCHING.md
+++ b/PREFAB_PATCHING.md
@@ -25,11 +25,16 @@ local experimental manifests from their authoring variants whenever the schema
 changes.
 
 Compiled JSON contains the local `patchName`, operations, dependencies, and
-target identity. It does not serialize a mod ID or mod version. In editor Play
-Mode, the owning Mod authoring asset supplies the ID. In a player, Patch
-Manager associates each manifest's Addressables catalog with the SpaceWarp
-descriptor that loaded it and uses that descriptor's `swinfo` ID. The
-fully-qualified `mod-id:patch-name` exists only in the resolved runtime model.
+target identity. It does not serialize a mod ID or mod version. Each SpaceWarp
+descriptor declares an `addressable_prefab_patch_label`; Patch Manager queries
+that label in both editor Play Mode and players and assigns the descriptor's
+`swinfo` ID to every returned manifest. The manifest asset's own Addressables
+address is not patch identity. The fully-qualified `mod-id:patch-name` exists
+only in the resolved runtime model.
+
+KSP2UnityTools-generated mods default to `<mod-id>_prefab_patches`. Redux uses
+`redux_prefab_patches`. Script TextAssets use the parallel
+`<mod-id>_patches`/`redux_patches` convention. Loose Lua files remain supported.
 
 ## Visual authoring
 

--- a/PREFAB_PATCHING.md.meta
+++ b/PREFAB_PATCHING.md.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 83f20edca85b417b85fd52fa4518a929

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 A mod for generic patching needs similar to KSP 1's Module Manager.
 
 Documentation: https://ksp2community.github.io/PatchManagerDocs/
+
+Prefab patch visual, C#, and Lua authoring is documented in
+[PREFAB_PATCHING.md](PREFAB_PATCHING.md).

--- a/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs
+++ b/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs
@@ -1,0 +1,19 @@
+using PatchManager.PrefabPatching;
+
+namespace PatchManager.CSharpPatching
+{
+    /// <summary>
+    /// Mod-scoped C# frontend for declarative prefab patches.
+    /// </summary>
+    public static class PrefabPatchingCSharpPatching
+    {
+        /// <summary>
+        /// Creates a prefab patch owned by the calling mod's swinfo identity.
+        /// </summary>
+        public static PrefabPatchBuilder PatchPrefab(
+            this PmScope scope,
+            string name,
+            PrefabPatchPrefabIdentity target
+        ) => new(scope.ModId, name, target);
+    }
+}

--- a/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs
+++ b/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs
@@ -15,5 +15,16 @@ namespace PatchManager.CSharpPatching
             string name,
             PrefabPatchPrefabIdentity target
         ) => new(scope.ModId, name, target);
+
+        /// <summary>
+        /// Creates a prefab patch targeting a stock Addressables key.
+        /// Canonical bundle and CAB metadata are not part of imperative
+        /// authoring.
+        /// </summary>
+        public static PrefabPatchBuilder PatchPrefab(
+            this PmScope scope,
+            string name,
+            string address
+        ) => new(scope.ModId, name, address);
     }
 }

--- a/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs
+++ b/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs
@@ -10,12 +10,6 @@ namespace PatchManager.CSharpPatching
         /// <summary>
         /// Creates a prefab patch owned by the calling mod's swinfo identity.
         /// </summary>
-        public static PrefabPatchBuilder PatchPrefab(
-            this PmScope scope,
-            string name,
-            PrefabPatchPrefabIdentity target
-        ) => new(scope.ModId, name, target);
-
         /// <summary>
         /// Creates a prefab patch targeting a stock Addressables key.
         /// Canonical bundle and CAB metadata are not part of imperative

--- a/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs.meta
+++ b/Runtime/CSharpPatching/PrefabPatchingCSharpPatching.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9063ecf1f9c8734abf1ed5334198e30

--- a/Runtime/Core/Assets/Locators.cs
+++ b/Runtime/Core/Assets/Locators.cs
@@ -39,11 +39,29 @@ namespace PatchManager.Core.Assets
         /// <returns>True if any assets were found, false otherwise.</returns>
         public static bool LocateAll(object label, out List<IResourceLocation> locations)
         {
+            return LocateAll(label, typeof(TextAsset), out locations);
+        }
+
+        /// <summary>
+        /// Locate assets by key and requested type across every Patch Manager
+        /// asset-domain locator.
+        /// </summary>
+        public static bool LocateAll(
+            object key,
+            System.Type type,
+            out List<IResourceLocation> locations
+        )
+        {
             locations = new List<IResourceLocation>();
             foreach (var locator in ResourceLocators)
             {
-                locator.Locate(label, typeof(TextAsset), out var foundLocations);
-                locations.AddRange(foundLocations);
+                if (
+                    locator.Locate(key, type, out var foundLocations)
+                    && foundLocations != null
+                )
+                {
+                    locations.AddRange(foundLocations);
+                }
             }
 
             return locations.Count > 0;

--- a/Runtime/Core/Cache/CacheManager.cs
+++ b/Runtime/Core/Cache/CacheManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using PatchManager.Core.Cache.Json;
+using PatchManager.PrefabPatching;
 using PatchManager.Shared;
 
 namespace PatchManager.Core.Cache
@@ -165,7 +166,7 @@ namespace PatchManager.Core.Cache
 
         public static void SaveSummary(Summary universeSummary)
         {
-            File.WriteAllText("./pm_summary.log", universeSummary.Dump());
+            PatchManagerSummaryLog.UpdateCoreSummary(universeSummary.Dump());
         }
     }
 }

--- a/Runtime/Core/CoreModule.cs
+++ b/Runtime/Core/CoreModule.cs
@@ -6,6 +6,7 @@ using KSP.Game.Flow;
 using PatchManager.Core.Assets;
 using PatchManager.Core.Cache;
 using PatchManager.LuaPatching;
+using PatchManager.PrefabPatching;
 using PatchManager.Shared;
 using PatchManager.Shared.Modules;
 using ReduxLib.Configuration;
@@ -78,6 +79,12 @@ namespace PatchManager.Core
                 tail.Add(new GenericFlowAction("Patch Manager: Saving Patch Summary", SavePatchSummary));
             }
 
+            tail.Add(
+                new GenericFlowAction(
+                    "Patch Manager: Resolving Prefab Patch Plans",
+                    ResolvePrefabPatchPlans
+                )
+            );
             tail.Add(new GenericFlowAction("Patch Manager: Registering Resource Locator", RegisterResourceLocator));
 
             // Splice the tail in right after this step. Insert back-to-front so each Insert at the same index
@@ -94,7 +101,20 @@ namespace PatchManager.Core
         private static void CloseRegistration(Action resolve, Action<string> reject)
         {
             PatchingManager.Universe.RegistrationOpen = false;
+            PrefabPatchRuntime.CloseRegistration();
             resolve();
+        }
+
+        private static void ResolvePrefabPatchPlans(
+            Action resolve,
+            Action<string> reject
+        )
+        {
+            PrefabPatchRuntime.DiscoverAndResolve(
+                PatchingManager.Universe.AllMods,
+                resolve,
+                reject
+            );
         }
 
         private void SavePatchSummary(Action resolve, Action<string> reject)
@@ -149,6 +169,7 @@ namespace PatchManager.Core
             }
 
             Locators.Register(new ArchiveResourceLocator());
+            PrefabPatchRuntime.RegisterResourceProvider();
             GameManager.Instance.Game.UI.UitkLoadingCurtain.Data.PatchManagerDefinitionsModifiedCount =
                 CacheManager.Inventory.DefinitionCount;
             GameManager.Instance.Game.UI.UitkLoadingCurtain.Data.PatchManagerNewAssetCount =
@@ -191,6 +212,15 @@ namespace PatchManager.Core
             {
                 text.text += $"\n- {label}";
             }
+
+            var prefabMetrics = PrefabPatchRuntime.CurrentMetrics;
+            text.text +=
+                $"\nPrefab plans: {prefabMetrics.ResolvedPlanCount}"
+                + $" ({prefabMetrics.CacheHitCount} cache hit(s), "
+                + $"{prefabMetrics.CacheMissCount} miss(es))";
+            text.text +=
+                $"\nRetained prefab handles: "
+                + $"{prefabMetrics.RetainedAddressablesHandles}";
 
             text.visible = true;
             text.style.display = DisplayStyle.Flex;

--- a/Runtime/Core/CoreModule.cs
+++ b/Runtime/Core/CoreModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using KSP.Game;
 using KSP.Game.Flow;
@@ -11,6 +12,7 @@ using PatchManager.Shared;
 using PatchManager.Shared.Modules;
 using ReduxLib.Configuration;
 using ReduxLib.Configuration.Attributes;
+using SpaceWarp2.API.Mods;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.UIElements;
@@ -135,8 +137,28 @@ namespace PatchManager.Core
             Action<string> reject
         )
         {
+            var catalogOwners = PluginList.AllEnabledAndActivePlugins
+                .SelectMany(descriptor =>
+                    descriptor.AddressableResourceLocators.Select(locator =>
+                        new
+                        {
+                            locator.LocatorId,
+                            descriptor.Guid
+                        }
+                    )
+                )
+                .GroupBy(value => value.LocatorId, StringComparer.Ordinal)
+                .ToDictionary(
+                    group => group.Key,
+                    group =>
+                        group.Select(value => value.Guid)
+                            .Distinct(StringComparer.Ordinal)
+                            .Single(),
+                    StringComparer.Ordinal
+                );
             PrefabPatchRuntime.DiscoverAndResolve(
                 PatchingManager.Universe.AllMods,
+                catalogOwners,
                 resolve,
                 reject
             );

--- a/Runtime/Core/CoreModule.cs
+++ b/Runtime/Core/CoreModule.cs
@@ -48,6 +48,31 @@ namespace PatchManager.Core
         /// </remarks>
         public override void Init()
         {
+            RegisterLoadingActions();
+        }
+
+        [RuntimeInitializeOnLoadMethod(
+            RuntimeInitializeLoadType.AfterAssembliesLoaded
+        )]
+        private static void RestoreLoadingActionsWithoutDomainReload()
+        {
+            // SpaceWarp resets GeneralLoadingActions at SubsystemRegistration.
+            // With domain reload disabled PatchManager's MonoBehaviour and module
+            // instances survive, so Awake/Init do not run again to repopulate it.
+            // AfterAssembliesLoaded runs after that reset and before SpaceWarp
+            // builds the new play session's loading flow.
+            foreach (var module in ModuleManager.Modules)
+            {
+                if (module is CoreModule core)
+                {
+                    core.RegisterLoadingActions();
+                    return;
+                }
+            }
+        }
+
+        private void RegisterLoadingActions()
+        {
             SpaceWarp2.API.Loading.Loading.GeneralLoadingActions.Insert(0,
                 () => new FlowAction("Patch Manager: Closing Registration", CloseRegistration));
             SpaceWarp2.API.Loading.Loading.GeneralLoadingActions.Insert(1,

--- a/Runtime/Core/CoreModule.cs
+++ b/Runtime/Core/CoreModule.cs
@@ -169,7 +169,7 @@ namespace PatchManager.Core
             }
 
             Locators.Register(new ArchiveResourceLocator());
-            PrefabPatchRuntime.RegisterResourceProvider();
+            Locators.Register(PrefabPatchRuntime.RegisterResourceProvider());
             GameManager.Instance.Game.UI.UitkLoadingCurtain.Data.PatchManagerDefinitionsModifiedCount =
                 CacheManager.Inventory.DefinitionCount;
             GameManager.Instance.Game.UI.UitkLoadingCurtain.Data.PatchManagerNewAssetCount =

--- a/Runtime/Core/CoreModule.cs
+++ b/Runtime/Core/CoreModule.cs
@@ -137,28 +137,25 @@ namespace PatchManager.Core
             Action<string> reject
         )
         {
-            var catalogOwners = PluginList.AllEnabledAndActivePlugins
-                .SelectMany(descriptor =>
-                    descriptor.AddressableResourceLocators.Select(locator =>
-                        new
+            var manifestSources =
+                PluginList.AllEnabledAndActivePlugins
+                    .Where(descriptor =>
+                        !string.IsNullOrWhiteSpace(
+                            descriptor.AddressablePrefabPatchLabel
+                        )
+                    )
+                    .Select(descriptor =>
+                        new PrefabPatchManifestSource
                         {
-                            locator.LocatorId,
-                            descriptor.Guid
+                            OwnerModId = descriptor.Guid,
+                            AddressablesLabel =
+                                descriptor.AddressablePrefabPatchLabel
                         }
                     )
-                )
-                .GroupBy(value => value.LocatorId, StringComparer.Ordinal)
-                .ToDictionary(
-                    group => group.Key,
-                    group =>
-                        group.Select(value => value.Guid)
-                            .Distinct(StringComparer.Ordinal)
-                            .Single(),
-                    StringComparer.Ordinal
-                );
+                    .ToArray();
             PrefabPatchRuntime.DiscoverAndResolve(
                 PatchingManager.Universe.AllMods,
-                catalogOwners,
+                manifestSources,
                 resolve,
                 reject
             );

--- a/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
+++ b/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
@@ -86,9 +86,7 @@ public sealed class PatchManagerCore
     }
 
     /// <summary>
-    /// Begins a declarative prefab patch. Normal Lua authoring passes an
-    /// Addressables key string; generated tooling may pass a complete
-    /// PrefabPatchPrefabIdentity table.
+    /// Begins a declarative prefab patch for one stock Addressables key.
     /// </summary>
     public PrefabPatchLuaBuilder Prefab(
         ScriptExecutionContext context,
@@ -107,12 +105,15 @@ public sealed class PatchManagerCore
         var modId = context.CurrentGlobalEnv
             .Get("ModId")
             .CastToString();
-        var identity = target.Type == DataType.String
-            ? global::PatchManager.PrefabPatching.PrefabPatchPrefabIdentity
-                .FromAddress(target.String)
-            : PrefabPatchLuaBuilder.Model<
-                global::PatchManager.PrefabPatching.PrefabPatchPrefabIdentity
-            >(target, "prefab identity or Addressables key");
+        if (target.Type != DataType.String)
+        {
+            throw new ScriptRuntimeException(
+                "PM:Prefab expects the stock prefab's Addressables key."
+            );
+        }
+        var identity =
+            global::PatchManager.PrefabPatching.PrefabPatchPrefabIdentity
+                .FromAddress(target.String);
         return new PrefabPatchLuaBuilder(
             new global::PatchManager.PrefabPatching.PrefabPatchBuilder(
                 modId,

--- a/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
+++ b/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
@@ -86,6 +86,43 @@ public sealed class PatchManagerCore
     }
 
     /// <summary>
+    /// Begins a declarative prefab patch. The target is a Lua table matching
+    /// PrefabPatchPrefabIdentity; every operation added to the returned
+    /// builder is converted into the shared public prefab-patch schema.
+    /// </summary>
+    public PrefabPatchLuaBuilder Prefab(
+        ScriptExecutionContext context,
+        string name,
+        DynValue target,
+        string modVersion = null
+    )
+    {
+        if (!_universe.RegistrationOpen)
+        {
+            throw new ScriptRuntimeException(
+                $"PM:Prefab('{name}') can only be called during patch "
+                    + "registration."
+            );
+        }
+
+        var modId = context.CurrentGlobalEnv
+            .Get("ModId")
+            .CastToString();
+        var identity =
+            PrefabPatchLuaBuilder.Model<
+                global::PatchManager.PrefabPatching.PrefabPatchPrefabIdentity
+            >(target, "prefab identity");
+        return new PrefabPatchLuaBuilder(
+            new global::PatchManager.PrefabPatching.PrefabPatchBuilder(
+                modId,
+                name,
+                identity,
+                modVersion
+            )
+        );
+    }
+
+    /// <summary>
     /// Queues a brand-new asset for creation under the given label and address.
     /// </summary>
     /// <param name="converter">The name of the converter that will serialize <paramref name="newObject" /> to JSON.</param>

--- a/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
+++ b/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
@@ -86,9 +86,9 @@ public sealed class PatchManagerCore
     }
 
     /// <summary>
-    /// Begins a declarative prefab patch. The target is a Lua table matching
-    /// PrefabPatchPrefabIdentity; every operation added to the returned
-    /// builder is converted into the shared public prefab-patch schema.
+    /// Begins a declarative prefab patch. Normal Lua authoring passes an
+    /// Addressables key string; generated tooling may pass a complete
+    /// PrefabPatchPrefabIdentity table.
     /// </summary>
     public PrefabPatchLuaBuilder Prefab(
         ScriptExecutionContext context,
@@ -107,10 +107,12 @@ public sealed class PatchManagerCore
         var modId = context.CurrentGlobalEnv
             .Get("ModId")
             .CastToString();
-        var identity =
-            PrefabPatchLuaBuilder.Model<
+        var identity = target.Type == DataType.String
+            ? global::PatchManager.PrefabPatching.PrefabPatchPrefabIdentity
+                .FromAddress(target.String)
+            : PrefabPatchLuaBuilder.Model<
                 global::PatchManager.PrefabPatching.PrefabPatchPrefabIdentity
-            >(target, "prefab identity");
+            >(target, "prefab identity or Addressables key");
         return new PrefabPatchLuaBuilder(
             new global::PatchManager.PrefabPatching.PrefabPatchBuilder(
                 modId,

--- a/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
+++ b/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
@@ -93,8 +93,7 @@ public sealed class PatchManagerCore
     public PrefabPatchLuaBuilder Prefab(
         ScriptExecutionContext context,
         string name,
-        DynValue target,
-        string modVersion = null
+        DynValue target
     )
     {
         if (!_universe.RegistrationOpen)
@@ -116,8 +115,7 @@ public sealed class PatchManagerCore
             new global::PatchManager.PrefabPatching.PrefabPatchBuilder(
                 modId,
                 name,
-                identity,
-                modVersion
+                identity
             )
         );
     }

--- a/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
+++ b/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
@@ -280,6 +280,13 @@ public sealed class PrefabPatchLuaBuilder
     {
         try
         {
+            if (
+                value.Type == DataType.UserData
+                && value.UserData?.Object is T model
+            )
+            {
+                return model;
+            }
             var token = JsonUserData.GetJTokenForDynValue(value);
             token = NormalizeEmptyTables(token, typeof(T));
             var serializer = JsonSerializer.Create(

--- a/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
+++ b/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using MoonSharp.Interpreter;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PatchManager.PrefabPatching;
+
+namespace PatchManager.LuaPatching.Builtin;
+
+/// <summary>
+/// Lua frontend for the public declarative prefab-patch schema. Lua tables are
+/// converted directly into the same model used by C# and visual authoring.
+/// </summary>
+[MoonSharpUserData]
+public sealed class PrefabPatchLuaBuilder
+{
+    private readonly PrefabPatchBuilder _builder;
+
+    internal PrefabPatchLuaBuilder(PrefabPatchBuilder builder)
+    {
+        _builder = builder;
+    }
+
+    public PrefabPatchLuaBuilder Early()
+    {
+        _builder.Early();
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Late()
+    {
+        _builder.Late();
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder First()
+    {
+        _builder.First();
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Last()
+    {
+        _builder.Last();
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Needs(params string[] ids)
+    {
+        _builder.NeedsMod(ids);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Conflicts(params string[] ids)
+    {
+        _builder.ConflictsMod(ids);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder NeedsPatch(params string[] ids)
+    {
+        _builder.NeedsPatch(ids);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder ConflictsPatch(params string[] ids)
+    {
+        _builder.ConflictsPatch(ids);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder BeforePatch(params string[] ids)
+    {
+        _builder.BeforePatch(ids);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder AfterPatch(params string[] ids)
+    {
+        _builder.AfterPatch(ids);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Before(params string[] modIds)
+    {
+        _builder.BeforeMod(modIds);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder After(params string[] modIds)
+    {
+        _builder.AfterMod(modIds);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Configuration(params string[] inputs)
+    {
+        _builder.Configuration(inputs);
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Set(
+        string operationId,
+        DynValue target,
+        string propertyPath,
+        DynValue value
+    )
+    {
+        _builder.SetValue(
+            operationId,
+            Model<PrefabPatchObjectTarget>(target, "operation target"),
+            propertyPath,
+            Value(value)
+        );
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Reference(
+        string operationId,
+        DynValue target,
+        string propertyPath,
+        DynValue reference
+    )
+    {
+        _builder.SetObjectReference(
+            operationId,
+            Model<PrefabPatchObjectTarget>(target, "operation target"),
+            propertyPath,
+            Model<PrefabPatchObjectReference>(
+                reference,
+                "object reference"
+            )
+        );
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Active(
+        string operationId,
+        DynValue target,
+        bool active
+    )
+    {
+        _builder.SetActive(
+            operationId,
+            Model<PrefabPatchObjectTarget>(target, "operation target"),
+            active
+        );
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder Suppress(
+        string operationId,
+        DynValue target
+    )
+    {
+        _builder.SuppressObject(
+            operationId,
+            Model<PrefabPatchObjectTarget>(target, "operation target")
+        );
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder AddObject(
+        string operationId,
+        DynValue parent,
+        DynValue fragment
+    )
+    {
+        _builder.AddObject(
+            operationId,
+            parent.IsNil()
+                ? null
+                : Model<PrefabPatchObjectTarget>(
+                    parent,
+                    "parent target"
+                ),
+            Model<PrefabPatchObjectFragment>(
+                fragment,
+                "object fragment"
+            )
+        );
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder AddComponent(
+        string operationId,
+        DynValue target,
+        DynValue component
+    )
+    {
+        _builder.AddComponent(
+            operationId,
+            Model<PrefabPatchObjectTarget>(target, "operation target"),
+            Model<PrefabPatchComponentFragment>(
+                component,
+                "component fragment"
+            )
+        );
+        return this;
+    }
+
+    public PrefabPatchLuaBuilder RemoveComponent(
+        string operationId,
+        DynValue target
+    )
+    {
+        _builder.RemoveComponent(
+            operationId,
+            Model<PrefabPatchObjectTarget>(target, "component target")
+        );
+        return this;
+    }
+
+    public PrefabPatchManifest Build() => _builder.Build();
+
+    public PrefabPatchManifest Register() => _builder.Register();
+
+    private static PrefabPatchValue Value(DynValue value)
+    {
+        switch (value.Type)
+        {
+            case DataType.Boolean:
+                return PrefabPatchValue.FromBoolean(value.Boolean);
+            case DataType.Number:
+                return PrefabPatchValue.FromFloat(value.Number);
+            case DataType.String:
+                return PrefabPatchValue.FromString(value.String);
+            case DataType.Table:
+            case DataType.UserData:
+                return Model<PrefabPatchValue>(
+                    value,
+                    "typed prefab-patch value"
+                );
+            default:
+                throw new ScriptRuntimeException(
+                    $"Prefab patch values cannot be '{value.Type}'."
+                );
+        }
+    }
+
+    internal static T Model<T>(DynValue value, string description)
+    {
+        try
+        {
+            var token = JsonUserData.GetJTokenForDynValue(value);
+            token = NormalizeEmptyTables(token, typeof(T));
+            var serializer = JsonSerializer.Create(
+                PrefabPatchJson.Settings
+            );
+            var result = token.ToObject<T>(serializer);
+            if (result == null)
+            {
+                throw new ScriptRuntimeException(
+                    $"Expected {description}, got nil."
+                );
+            }
+            return result;
+        }
+        catch (ScriptRuntimeException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new ScriptRuntimeException(
+                $"Invalid {description}: {exception.Message}"
+            );
+        }
+    }
+
+    private static JToken NormalizeEmptyTables(
+        JToken token,
+        Type expectedType
+    )
+    {
+        if (
+            token is JObject emptyObject
+            && !emptyObject.Properties().Any()
+            && IsCollection(expectedType)
+        )
+            return new JArray();
+        if (token is JArray array)
+        {
+            var itemType = CollectionItemType(expectedType);
+            if (itemType != null)
+            {
+                for (var index = 0; index < array.Count; index++)
+                    array[index] = NormalizeEmptyTables(
+                        array[index],
+                        itemType
+                    );
+            }
+            return array;
+        }
+        if (token is not JObject value)
+            return token;
+
+        const BindingFlags flags =
+            BindingFlags.Instance | BindingFlags.Public;
+        foreach (var field in expectedType.GetFields(flags))
+        {
+            var camelName =
+                char.ToLowerInvariant(field.Name[0])
+                + field.Name.Substring(1);
+            var property = value.Property(
+                    camelName,
+                    StringComparison.OrdinalIgnoreCase
+                )
+                ?? value.Property(
+                    field.Name,
+                    StringComparison.OrdinalIgnoreCase
+                );
+            if (property != null)
+                property.Value = NormalizeEmptyTables(
+                    property.Value,
+                    field.FieldType
+                );
+        }
+        return value;
+    }
+
+    private static bool IsCollection(Type type) =>
+        type.IsArray
+        || (
+            type != typeof(string)
+            && typeof(IEnumerable).IsAssignableFrom(type)
+        );
+
+    private static Type CollectionItemType(Type type) =>
+        type.IsArray
+            ? type.GetElementType()
+            : type.IsGenericType
+                ? type.GetGenericArguments()[0]
+                : null;
+}

--- a/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
+++ b/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
@@ -117,6 +117,42 @@ public sealed class PrefabPatchLuaBuilder
         return this;
     }
 
+    public PrefabPatchLuaBuilder SetComponent(
+        string operationId,
+        string hierarchyPath,
+        string componentType,
+        string propertyPath,
+        DynValue value,
+        int componentOrdinal = 0
+    )
+    {
+        _builder.SetValue(
+            operationId,
+            PrefabPatchBuilder.ComponentAt(
+                hierarchyPath,
+                componentType,
+                componentOrdinal
+            ),
+            propertyPath,
+            Value(value)
+        );
+        return this;
+    }
+
+    public PrefabPatchObjectTarget GameObject(string hierarchyPath) =>
+        PrefabPatchBuilder.GameObjectAt(hierarchyPath);
+
+    public PrefabPatchObjectTarget Component(
+        string hierarchyPath,
+        string componentType,
+        int componentOrdinal = 0
+    ) =>
+        PrefabPatchBuilder.ComponentAt(
+            hierarchyPath,
+            componentType,
+            componentOrdinal
+        );
+
     public PrefabPatchLuaBuilder Reference(
         string operationId,
         DynValue target,

--- a/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
+++ b/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
@@ -249,9 +249,13 @@ public sealed class PrefabPatchLuaBuilder
         return this;
     }
 
-    public PrefabPatchManifest Build() => _builder.Build();
+    public JsonUserData Build() =>
+        new(JToken.Parse(PrefabPatchJson.Serialize(_builder.Build())));
 
-    public PrefabPatchManifest Register() => _builder.Register();
+    public void Register()
+    {
+        _builder.Register();
+    }
 
     private static PrefabPatchValue Value(DynValue value)
     {

--- a/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs.meta
+++ b/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0a738bdf2e64d789dbfb74b4c881f1d

--- a/Runtime/PrefabPatching.meta
+++ b/Runtime/PrefabPatching.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 840fdb67dba5bef47b5ed07fb118481e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/PrefabPatching/PatchManager.PrefabPatching.asmdef
+++ b/Runtime/PrefabPatching/PatchManager.PrefabPatching.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "PatchManager.PrefabPatching",
+    "rootNamespace": "PatchManager.PrefabPatching",
+    "references": [
+        "Unity.Addressables",
+        "Unity.ResourceManager"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Runtime/PrefabPatching/PatchManager.PrefabPatching.asmdef.meta
+++ b/Runtime/PrefabPatching/PatchManager.PrefabPatching.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8689a1c3eae3ae34a84c40b6173daf4f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/PrefabPatching/PrefabPatchBuilder.cs
+++ b/Runtime/PrefabPatching/PrefabPatchBuilder.cs
@@ -10,6 +10,7 @@ namespace PatchManager.PrefabPatching;
 /// </summary>
 public sealed class PrefabPatchBuilder
 {
+    private readonly string _modId;
     private readonly PrefabPatchManifest _manifest;
     private readonly HashSet<string> _needsMods = new(StringComparer.Ordinal);
     private readonly HashSet<string> _conflictsMods = new(
@@ -29,8 +30,7 @@ public sealed class PrefabPatchBuilder
     public PrefabPatchBuilder(
         string modId,
         string patchName,
-        PrefabPatchPrefabIdentity target,
-        string modVersion = null
+        PrefabPatchPrefabIdentity target
     )
     {
         if (string.IsNullOrWhiteSpace(modId))
@@ -40,14 +40,15 @@ public sealed class PrefabPatchBuilder
                 "Patch name is required.",
                 nameof(patchName)
             );
+        if (patchName.IndexOf(':') >= 0)
+            throw new ArgumentException(
+                "Patch name must be local to the mod and cannot contain ':'.",
+                nameof(patchName)
+            );
+        _modId = modId.Trim();
         _manifest = new PrefabPatchManifest
         {
-            PatchId =
-                patchName.IndexOf(':') >= 0
-                    ? patchName
-                    : modId + ":" + patchName,
-            ModId = modId,
-            ModVersion = modVersion,
+            PatchName = patchName.Trim(),
             TargetPrefab =
                 target ?? throw new ArgumentNullException(nameof(target))
         };
@@ -105,7 +106,10 @@ public sealed class PrefabPatchBuilder
     {
         if (operation == null)
             throw new ArgumentNullException(nameof(operation));
-        operation.PatchId = _manifest.PatchId;
+        operation.PatchId = PrefabPatchOwnership.Qualify(
+            _modId,
+            _manifest.PatchName
+        );
         _manifest.Operations.Add(operation);
         return this;
     }
@@ -292,7 +296,7 @@ public sealed class PrefabPatchBuilder
             .OrderBy(value => value, StringComparer.Ordinal)
             .ToArray();
         _manifest.ManifestHash = PrefabPatchJson.CalculateManifestHash(_manifest);
-        return _manifest;
+        return PrefabPatchOwnership.Bind(_manifest, _modId);
     }
 
     public PrefabPatchManifest Register()
@@ -319,13 +323,8 @@ public sealed class PrefabPatchBuilder
         return this;
     }
 
-    private IEnumerable<string> Normalize(IEnumerable<string> ids) =>
-        (ids ?? Array.Empty<string>()).Select(
-            id =>
-                id.IndexOf(':') >= 0
-                    ? id
-                    : _manifest.ModId + ":" + id
-        );
+    private static IEnumerable<string> Normalize(IEnumerable<string> ids) =>
+        ids ?? Array.Empty<string>();
 
     private static string[] Sorted(IEnumerable<string> values) =>
         values.OrderBy(value => value, StringComparer.Ordinal).ToArray();

--- a/Runtime/PrefabPatching/PrefabPatchBuilder.cs
+++ b/Runtime/PrefabPatching/PrefabPatchBuilder.cs
@@ -142,6 +142,36 @@ public sealed class PrefabPatchBuilder
             }
         );
 
+    public PrefabPatchBuilder SetObjectReference(
+        string operationId,
+        PrefabPatchObjectTarget target,
+        string propertyPath,
+        PrefabPatchObjectReference reference
+    ) =>
+        AddOperation(
+            new PrefabPatchOperation
+            {
+                OperationId = operationId,
+                Kind = PrefabPatchOperationKind.SetObjectReference,
+                Target = target,
+                PropertyPath = propertyPath,
+                ObjectReference = reference
+            }
+        );
+
+    public PrefabPatchBuilder SuppressObject(
+        string operationId,
+        PrefabPatchObjectTarget target
+    ) =>
+        AddOperation(
+            new PrefabPatchOperation
+            {
+                OperationId = operationId,
+                Kind = PrefabPatchOperationKind.SuppressObject,
+                Target = target
+            }
+        );
+
     public PrefabPatchBuilder AddObject(
         string operationId,
         PrefabPatchObjectTarget parent,
@@ -157,6 +187,95 @@ public sealed class PrefabPatchBuilder
             }
         );
 
+    public PrefabPatchBuilder AddComponent(
+        string operationId,
+        PrefabPatchObjectTarget target,
+        PrefabPatchComponentFragment component
+    ) =>
+        AddOperation(
+            new PrefabPatchOperation
+            {
+                OperationId = operationId,
+                Kind = PrefabPatchOperationKind.AddComponent,
+                Target = target,
+                AddedComponent = component
+            }
+        );
+
+    public PrefabPatchBuilder RemoveComponent(
+        string operationId,
+        PrefabPatchObjectTarget target
+    ) =>
+        AddOperation(
+            new PrefabPatchOperation
+            {
+                OperationId = operationId,
+                Kind = PrefabPatchOperationKind.RemoveComponent,
+                Target = target
+            }
+        );
+
+    public PrefabPatchBuilder Configuration(params string[] inputs)
+    {
+        _manifest.ConfigurationInputs = Sorted(
+            (_manifest.ConfigurationInputs ?? Array.Empty<string>())
+                .Concat(inputs ?? Array.Empty<string>())
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.Ordinal)
+        );
+        return this;
+    }
+
+    public static PrefabPatchObjectTarget PatchObject(
+        string ownerPatchId,
+        string objectId
+    ) =>
+        new()
+        {
+            Kind = PrefabPatchTargetKind.PatchOwned,
+            OwnerPatchId = ownerPatchId,
+            ObjectId = objectId,
+            RuntimeLocator = new PrefabPatchRuntimeLocator
+            {
+                TargetKind = PrefabPatchRuntimeTargetKind.GameObject,
+                SiblingIndices = Array.Empty<int>()
+            }
+        };
+
+    public static PrefabPatchObjectTarget PatchComponent(
+        string ownerPatchId,
+        string componentId
+    ) =>
+        new()
+        {
+            Kind = PrefabPatchTargetKind.PatchComponent,
+            OwnerPatchId = ownerPatchId,
+            ComponentId = componentId,
+            RuntimeLocator = new PrefabPatchRuntimeLocator
+            {
+                TargetKind = PrefabPatchRuntimeTargetKind.Component,
+                SiblingIndices = Array.Empty<int>()
+            }
+        };
+
+    public static PrefabPatchObjectReference Addressable(
+        string address,
+        Type expectedType = null
+    ) =>
+        PrefabPatchObjectReference.FromAddress(
+            address,
+            expectedType?.AssemblyQualifiedName
+        );
+
+    public static PrefabPatchObjectReference TargetReference(
+        PrefabPatchObjectTarget target,
+        Type expectedType = null
+    ) =>
+        PrefabPatchObjectReference.FromTarget(
+            target,
+            expectedType?.AssemblyQualifiedName
+        );
+
     public PrefabPatchManifest Build()
     {
         _manifest.NeedsMods = Sorted(_needsMods);
@@ -167,9 +286,6 @@ public sealed class PrefabPatchBuilder
         _manifest.AfterPatches = Sorted(_afterPatches);
         _manifest.BeforeMods = Sorted(_beforeMods);
         _manifest.AfterMods = Sorted(_afterMods);
-        _manifest.Operations = _manifest.Operations
-            .OrderBy(value => value.OperationId, StringComparer.Ordinal)
-            .ToList();
         _manifest.DeclaredCapabilities = _manifest.Operations
             .Select(value => value.Kind.ToString())
             .Distinct(StringComparer.Ordinal)

--- a/Runtime/PrefabPatching/PrefabPatchBuilder.cs
+++ b/Runtime/PrefabPatching/PrefabPatchBuilder.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Fluent C# frontend that generates the same declarative public manifest used
+/// by visual prefab-variant compilation.
+/// </summary>
+public sealed class PrefabPatchBuilder
+{
+    private readonly PrefabPatchManifest _manifest;
+    private readonly HashSet<string> _needsMods = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _conflictsMods = new(
+        StringComparer.Ordinal
+    );
+    private readonly HashSet<string> _needsPatches = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _conflictsPatches = new(
+        StringComparer.Ordinal
+    );
+    private readonly HashSet<string> _beforePatches = new(
+        StringComparer.Ordinal
+    );
+    private readonly HashSet<string> _afterPatches = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _beforeMods = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _afterMods = new(StringComparer.Ordinal);
+
+    public PrefabPatchBuilder(
+        string modId,
+        string patchName,
+        PrefabPatchPrefabIdentity target,
+        string modVersion = null
+    )
+    {
+        if (string.IsNullOrWhiteSpace(modId))
+            throw new ArgumentException("Mod ID is required.", nameof(modId));
+        if (string.IsNullOrWhiteSpace(patchName))
+            throw new ArgumentException(
+                "Patch name is required.",
+                nameof(patchName)
+            );
+        _manifest = new PrefabPatchManifest
+        {
+            PatchId =
+                patchName.IndexOf(':') >= 0
+                    ? patchName
+                    : modId + ":" + patchName,
+            ModId = modId,
+            ModVersion = modVersion,
+            TargetPrefab =
+                target ?? throw new ArgumentNullException(nameof(target))
+        };
+    }
+
+    public PrefabPatchBuilder Early()
+    {
+        _manifest.Pass = PrefabPatchPass.Early;
+        return this;
+    }
+
+    public PrefabPatchBuilder Late()
+    {
+        _manifest.Pass = PrefabPatchPass.Late;
+        return this;
+    }
+
+    public PrefabPatchBuilder First()
+    {
+        _manifest.Ordering = PrefabPatchOrdering.First;
+        return this;
+    }
+
+    public PrefabPatchBuilder Last()
+    {
+        _manifest.Ordering = PrefabPatchOrdering.Last;
+        return this;
+    }
+
+    public PrefabPatchBuilder NeedsMod(params string[] ids) =>
+        Add(_needsMods, ids);
+
+    public PrefabPatchBuilder ConflictsMod(params string[] ids) =>
+        Add(_conflictsMods, ids);
+
+    public PrefabPatchBuilder NeedsPatch(params string[] ids) =>
+        Add(_needsPatches, Normalize(ids));
+
+    public PrefabPatchBuilder ConflictsPatch(params string[] ids) =>
+        Add(_conflictsPatches, Normalize(ids));
+
+    public PrefabPatchBuilder BeforePatch(params string[] ids) =>
+        Add(_beforePatches, Normalize(ids));
+
+    public PrefabPatchBuilder AfterPatch(params string[] ids) =>
+        Add(_afterPatches, Normalize(ids));
+
+    public PrefabPatchBuilder BeforeMod(params string[] ids) =>
+        Add(_beforeMods, ids);
+
+    public PrefabPatchBuilder AfterMod(params string[] ids) =>
+        Add(_afterMods, ids);
+
+    public PrefabPatchBuilder AddOperation(PrefabPatchOperation operation)
+    {
+        if (operation == null)
+            throw new ArgumentNullException(nameof(operation));
+        operation.PatchId = _manifest.PatchId;
+        _manifest.Operations.Add(operation);
+        return this;
+    }
+
+    public PrefabPatchBuilder SetValue(
+        string operationId,
+        PrefabPatchObjectTarget target,
+        string propertyPath,
+        PrefabPatchValue value
+    ) =>
+        AddOperation(
+            new PrefabPatchOperation
+            {
+                OperationId = operationId,
+                Kind = PrefabPatchOperationKind.SetValue,
+                Target = target,
+                PropertyPath = propertyPath,
+                Value = value
+            }
+        );
+
+    public PrefabPatchBuilder SetActive(
+        string operationId,
+        PrefabPatchObjectTarget target,
+        bool active
+    ) =>
+        AddOperation(
+            new PrefabPatchOperation
+            {
+                OperationId = operationId,
+                Kind = PrefabPatchOperationKind.SetActive,
+                Target = target,
+                Value = PrefabPatchValue.FromBoolean(active)
+            }
+        );
+
+    public PrefabPatchBuilder AddObject(
+        string operationId,
+        PrefabPatchObjectTarget parent,
+        PrefabPatchObjectFragment fragment
+    ) =>
+        AddOperation(
+            new PrefabPatchOperation
+            {
+                OperationId = operationId,
+                Kind = PrefabPatchOperationKind.AddObject,
+                Target = parent,
+                AddedObject = fragment
+            }
+        );
+
+    public PrefabPatchManifest Build()
+    {
+        _manifest.NeedsMods = Sorted(_needsMods);
+        _manifest.ConflictsMods = Sorted(_conflictsMods);
+        _manifest.NeedsPatches = Sorted(_needsPatches);
+        _manifest.ConflictsPatches = Sorted(_conflictsPatches);
+        _manifest.BeforePatches = Sorted(_beforePatches);
+        _manifest.AfterPatches = Sorted(_afterPatches);
+        _manifest.BeforeMods = Sorted(_beforeMods);
+        _manifest.AfterMods = Sorted(_afterMods);
+        _manifest.Operations = _manifest.Operations
+            .OrderBy(value => value.OperationId, StringComparer.Ordinal)
+            .ToList();
+        _manifest.DeclaredCapabilities = _manifest.Operations
+            .Select(value => value.Kind.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .ToArray();
+        _manifest.ManifestHash = PrefabPatchJson.CalculateManifestHash(_manifest);
+        return _manifest;
+    }
+
+    public PrefabPatchManifest Register()
+    {
+        var manifest = Build();
+        PrefabPatchRuntime.Register(manifest);
+        return manifest;
+    }
+
+    private PrefabPatchBuilder Add(
+        ISet<string> destination,
+        IEnumerable<string> ids
+    )
+    {
+        foreach (
+            var id in (ids ?? Array.Empty<string>()).Where(
+                value => !string.IsNullOrWhiteSpace(value)
+            )
+        )
+        {
+            destination.Add(id);
+        }
+
+        return this;
+    }
+
+    private IEnumerable<string> Normalize(IEnumerable<string> ids) =>
+        (ids ?? Array.Empty<string>()).Select(
+            id =>
+                id.IndexOf(':') >= 0
+                    ? id
+                    : _manifest.ModId + ":" + id
+        );
+
+    private static string[] Sorted(IEnumerable<string> values) =>
+        values.OrderBy(value => value, StringComparer.Ordinal).ToArray();
+}

--- a/Runtime/PrefabPatching/PrefabPatchBuilder.cs
+++ b/Runtime/PrefabPatching/PrefabPatchBuilder.cs
@@ -54,6 +54,16 @@ public sealed class PrefabPatchBuilder
         };
     }
 
+    public PrefabPatchBuilder(
+        string modId,
+        string patchName,
+        string address
+    ) : this(
+        modId,
+        patchName,
+        PrefabPatchPrefabIdentity.FromAddress(address)
+    ) { }
+
     public PrefabPatchBuilder Early()
     {
         _manifest.Pass = PrefabPatchPass.Early;
@@ -262,6 +272,45 @@ public sealed class PrefabPatchBuilder
             }
         };
 
+    public static PrefabPatchObjectTarget GameObjectAt(
+        string hierarchyPath
+    ) =>
+        StockTarget(
+            hierarchyPath,
+            PrefabPatchRuntimeTargetKind.GameObject,
+            typeof(UnityEngine.GameObject).AssemblyQualifiedName,
+            0
+        );
+
+    public static PrefabPatchObjectTarget ComponentAt<TComponent>(
+        string hierarchyPath,
+        int componentOrdinal = 0
+    ) where TComponent : UnityEngine.Component =>
+        ComponentAt(
+            hierarchyPath,
+            typeof(TComponent).AssemblyQualifiedName,
+            componentOrdinal
+        );
+
+    public static PrefabPatchObjectTarget ComponentAt(
+        string hierarchyPath,
+        string componentType,
+        int componentOrdinal = 0
+    )
+    {
+        if (string.IsNullOrWhiteSpace(componentType))
+            throw new ArgumentException(
+                "Component type is required.",
+                nameof(componentType)
+            );
+        return StockTarget(
+            hierarchyPath,
+            PrefabPatchRuntimeTargetKind.Component,
+            componentType,
+            componentOrdinal
+        );
+    }
+
     public static PrefabPatchObjectReference Addressable(
         string address,
         Type expectedType = null
@@ -328,4 +377,43 @@ public sealed class PrefabPatchBuilder
 
     private static string[] Sorted(IEnumerable<string> values) =>
         values.OrderBy(value => value, StringComparer.Ordinal).ToArray();
+
+    private static PrefabPatchObjectTarget StockTarget(
+        string hierarchyPath,
+        PrefabPatchRuntimeTargetKind targetKind,
+        string objectType,
+        int componentOrdinal
+    )
+    {
+        if (hierarchyPath == null)
+            throw new ArgumentNullException(nameof(hierarchyPath));
+        if (componentOrdinal < 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(componentOrdinal)
+            );
+        var normalizedPath = string.Join(
+            "/",
+            hierarchyPath.Split(
+                new[] { '/' },
+                StringSplitOptions.RemoveEmptyEntries
+            )
+        );
+        return new PrefabPatchObjectTarget
+        {
+            Kind = PrefabPatchTargetKind.Stock,
+            ObjectType = objectType,
+            RuntimeLocator = new PrefabPatchRuntimeLocator
+            {
+                HierarchyPath = normalizedPath,
+                TargetKind = targetKind,
+                ComponentType =
+                    targetKind == PrefabPatchRuntimeTargetKind.Component
+                        ? objectType
+                        : null,
+                ComponentOrdinal = componentOrdinal,
+                DisplayPath = normalizedPath,
+                SiblingIndices = Array.Empty<int>()
+            }
+        };
+    }
 }

--- a/Runtime/PrefabPatching/PrefabPatchBuilder.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c2c844e10010e0643a7287766743f9b4

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs
@@ -1,0 +1,649 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Applies a validated resolved plan once to a loaded external prefab asset.
+/// The caller owns and retains the Addressables handles.
+/// </summary>
+public static class PrefabPatchComposer
+{
+    public sealed class Result
+    {
+        public bool Success;
+        public string Failure;
+        public long ElapsedMilliseconds;
+        public int AppliedOperationCount;
+        public Dictionary<string, GameObject> PatchOwnedObjects = new(
+            StringComparer.Ordinal
+        );
+    }
+
+    public static Result ApplySynchronously(
+        GameObject prefab,
+        PrefabPatchResolvedPlan plan,
+        IReadOnlyDictionary<string, Object> references
+    )
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var result = new Result();
+        try
+        {
+            if (prefab == null)
+                throw new ArgumentNullException(nameof(prefab));
+            if (plan == null || !plan.IsValid)
+                throw new InvalidOperationException(
+                    "The prefab patch plan is missing or invalid."
+                );
+            var actualFingerprint = PrefabPatchStructure.Calculate(prefab);
+            if (
+                !string.Equals(
+                    actualFingerprint,
+                    plan.TargetPrefab.StructuralFingerprint,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                throw new InvalidOperationException(
+                    $"Stock prefab '{plan.TargetPrefab.Address}' structural "
+                        + $"fingerprint changed. Expected "
+                        + $"'{plan.TargetPrefab.StructuralFingerprint}', got "
+                        + $"'{actualFingerprint}'. Recompile or repair the patch."
+                );
+            }
+
+            var unusedDeferredDestroy = false;
+            foreach (var operation in plan.Operations)
+            {
+                ApplyOne(
+                    prefab,
+                    operation,
+                    references,
+                    result.PatchOwnedObjects,
+                    ref unusedDeferredDestroy,
+                    true
+                );
+                result.AppliedOperationCount++;
+            }
+
+            result.Success = true;
+        }
+        catch (Exception exception)
+        {
+            result.Failure = exception.ToString();
+        }
+        finally
+        {
+            stopwatch.Stop();
+            result.ElapsedMilliseconds = stopwatch.ElapsedMilliseconds;
+        }
+
+        return result;
+    }
+
+    private static void ApplyOne(
+        GameObject root,
+        PrefabPatchOperation operation,
+        IReadOnlyDictionary<string, Object> references,
+        IDictionary<string, GameObject> patchOwned,
+        ref bool deferredDestroy,
+        bool immediateDestroy
+    )
+    {
+        if (operation.Kind == PrefabPatchOperationKind.AddObject)
+        {
+            var parentObject = operation.Target == null
+                ? root
+                : AsGameObject(Resolve(root, operation.Target, patchOwned));
+            if (parentObject == null)
+                throw MissingTarget(operation);
+            CreateFragment(
+                operation.PatchId,
+                operation.AddedObject,
+                parentObject.transform,
+                references,
+                patchOwned
+            );
+            return;
+        }
+
+        var target = Resolve(root, operation.Target, patchOwned);
+        if (target == null)
+            throw MissingTarget(operation);
+        switch (operation.Kind)
+        {
+            case PrefabPatchOperationKind.SetValue:
+                SetValue(target, operation.PropertyPath, operation.Value);
+                return;
+            case PrefabPatchOperationKind.SetObjectReference:
+                if (
+                    operation.ObjectReference == null
+                    || !references.TryGetValue(
+                        operation.ObjectReference.Address,
+                        out var reference
+                    )
+                    || reference == null
+                )
+                {
+                    throw new InvalidOperationException(
+                        $"Operation '{operation.OperationId}' could not resolve "
+                            + $"object reference "
+                            + $"'{operation.ObjectReference?.Address}'."
+                    );
+                }
+
+                SetRawValue(target, operation.PropertyPath, reference);
+                return;
+            case PrefabPatchOperationKind.SetActive:
+                AsGameObject(target)?.SetActive(
+                    operation.Value?.Boolean ?? false
+                );
+                return;
+            case PrefabPatchOperationKind.SuppressObject:
+                AsGameObject(target)?.SetActive(false);
+                return;
+            case PrefabPatchOperationKind.AddComponent:
+                AddComponent(
+                    AsGameObject(target),
+                    operation.AddedComponent,
+                    references
+                );
+                return;
+            case PrefabPatchOperationKind.RemoveComponent:
+                if (target is not Component component)
+                {
+                    throw new InvalidOperationException(
+                        $"RemoveComponent operation '{operation.OperationId}' "
+                            + "did not resolve to a Component."
+                    );
+                }
+
+                if (immediateDestroy)
+                    Object.DestroyImmediate(component);
+                else
+                {
+                    Object.Destroy(component);
+                    deferredDestroy = true;
+                }
+                return;
+            default:
+                throw new NotSupportedException(
+                    $"Prefab operation kind '{operation.Kind}' is not supported "
+                        + $"by composer {PrefabPatchSchema.ComposerVersion}."
+                );
+        }
+    }
+
+    private static Object Resolve(
+        GameObject root,
+        PrefabPatchObjectTarget target,
+        IDictionary<string, GameObject> patchOwned
+    )
+    {
+        Transform transform;
+        if (target.Kind == PrefabPatchTargetKind.Stock)
+        {
+            transform = PrefabPatchStructure.Resolve(
+                root.transform,
+                target.RuntimeLocator?.SiblingIndices
+            );
+        }
+        else
+        {
+            var key = $"{target.OwnerPatchId}:{target.ObjectId}";
+            if (!patchOwned.TryGetValue(key, out var owned) || owned == null)
+                return null;
+            transform = owned.transform;
+        }
+
+        if (transform == null)
+            return null;
+        if (
+            target.RuntimeLocator == null
+            || target.RuntimeLocator.TargetKind
+            == PrefabPatchRuntimeTargetKind.GameObject
+        )
+        {
+            return transform.gameObject;
+        }
+
+        var type = ResolveType(target.RuntimeLocator.ComponentType);
+        if (type == null || !typeof(Component).IsAssignableFrom(type))
+            return null;
+        var components = transform.gameObject.GetComponents(type);
+        var ordinal = target.RuntimeLocator.ComponentOrdinal;
+        return ordinal >= 0 && ordinal < components.Length
+            ? components[ordinal]
+            : null;
+    }
+
+    private static GameObject CreateFragment(
+        string patchId,
+        PrefabPatchObjectFragment fragment,
+        Transform parent,
+        IReadOnlyDictionary<string, Object> references,
+        IDictionary<string, GameObject> patchOwned
+    )
+    {
+        if (fragment == null || string.IsNullOrWhiteSpace(fragment.ObjectId))
+            throw new InvalidOperationException(
+                $"Patch '{patchId}' contains an invalid added-object fragment."
+            );
+        var key = $"{patchId}:{fragment.ObjectId}";
+        if (patchOwned.ContainsKey(key))
+            throw new InvalidOperationException(
+                $"Patch-owned object '{key}' already exists."
+            );
+
+        var gameObject = new GameObject(fragment.Name ?? fragment.ObjectId);
+        gameObject.transform.SetParent(parent, false);
+        gameObject.transform.localPosition = ToVector3(
+            fragment.LocalPosition,
+            Vector3.zero
+        );
+        gameObject.transform.localRotation = ToQuaternion(
+            fragment.LocalRotation,
+            Quaternion.identity
+        );
+        gameObject.transform.localScale = ToVector3(
+            fragment.LocalScale,
+            Vector3.one
+        );
+        gameObject.SetActive(fragment.Active);
+        gameObject.AddComponent<PrefabPatchObjectId>().Id = fragment.ObjectId;
+        patchOwned.Add(key, gameObject);
+        foreach (var component in fragment.Components)
+            AddComponent(gameObject, component, references);
+        foreach (var child in fragment.Children)
+            CreateFragment(patchId, child, gameObject.transform, references, patchOwned);
+        return gameObject;
+    }
+
+    private static Component AddComponent(
+        GameObject target,
+        PrefabPatchComponentFragment fragment,
+        IReadOnlyDictionary<string, Object> references
+    )
+    {
+        if (target == null || fragment == null)
+            throw new InvalidOperationException(
+                "An added component has no target or payload."
+            );
+        switch (fragment.Kind)
+        {
+            case PrefabPatchComponentKind.BoxCollider:
+            {
+                var value = target.AddComponent<BoxCollider>();
+                value.enabled = fragment.Enabled;
+                value.center = ToVector3(fragment.Center, Vector3.zero);
+                value.size = ToVector3(fragment.Size, Vector3.one);
+                value.isTrigger = fragment.IsTrigger;
+                return value;
+            }
+            case PrefabPatchComponentKind.SphereCollider:
+            {
+                var value = target.AddComponent<SphereCollider>();
+                value.enabled = fragment.Enabled;
+                value.center = ToVector3(fragment.Center, Vector3.zero);
+                value.radius = (float)fragment.Radius;
+                value.isTrigger = fragment.IsTrigger;
+                return value;
+            }
+            case PrefabPatchComponentKind.MeshFilter:
+            {
+                var value = target.AddComponent<MeshFilter>();
+                if (fragment.Mesh != null)
+                {
+                    if (
+                        !references.TryGetValue(
+                            fragment.Mesh.Address,
+                            out var reference
+                        )
+                        || reference is not Mesh mesh
+                    )
+                    {
+                        throw new InvalidOperationException(
+                            $"Could not resolve Mesh reference "
+                                + $"'{fragment.Mesh.Address}'."
+                        );
+                    }
+
+                    value.sharedMesh = mesh;
+                }
+
+                return value;
+            }
+            case PrefabPatchComponentKind.MeshRenderer:
+                return target.AddComponent<MeshRenderer>();
+            default:
+                throw new NotSupportedException(
+                    $"Added component kind '{fragment.Kind}' is unsupported."
+                );
+        }
+    }
+
+    private static void SetValue(
+        Object target,
+        string propertyPath,
+        PrefabPatchValue value
+    )
+    {
+        if (value == null)
+            throw new InvalidOperationException(
+                $"Property '{propertyPath}' has no typed value."
+            );
+        SetRawValue(target, propertyPath, ConvertValue(value));
+    }
+
+    private static void SetRawValue(
+        Object target,
+        string propertyPath,
+        object value
+    )
+    {
+        if (target is Transform transform)
+        {
+            if (TrySetTransform(transform, propertyPath, value))
+                return;
+        }
+
+        if (
+            target is GameObject gameObject
+            && (
+                propertyPath == "m_IsActive"
+                || propertyPath == "activeSelf"
+            )
+        )
+        {
+            gameObject.SetActive(Convert.ToBoolean(value, CultureInfo.InvariantCulture));
+            return;
+        }
+
+        SetMemberPath(target, propertyPath, value);
+    }
+
+    private static bool TrySetTransform(
+        Transform transform,
+        string propertyPath,
+        object value
+    )
+    {
+        var segments = propertyPath.Split('.');
+        if (segments.Length != 2)
+            return false;
+        var component = Convert.ToSingle(value, CultureInfo.InvariantCulture);
+        switch (segments[0])
+        {
+            case "m_LocalPosition":
+            case "localPosition":
+            {
+                var vector = transform.localPosition;
+                SetVectorComponent(ref vector, segments[1], component);
+                transform.localPosition = vector;
+                return true;
+            }
+            case "m_LocalScale":
+            case "localScale":
+            {
+                var vector = transform.localScale;
+                SetVectorComponent(ref vector, segments[1], component);
+                transform.localScale = vector;
+                return true;
+            }
+            case "m_LocalRotation":
+            case "localRotation":
+            {
+                var quaternion = transform.localRotation;
+                SetQuaternionComponent(
+                    ref quaternion,
+                    segments[1],
+                    component
+                );
+                transform.localRotation = quaternion;
+                return true;
+            }
+            default:
+                return false;
+        }
+    }
+
+    private static void SetMemberPath(
+        object root,
+        string path,
+        object value
+    )
+    {
+        var segments = path.Split('.');
+        SetMemberRecursive(root, segments, 0, value);
+    }
+
+    private static object SetMemberRecursive(
+        object current,
+        IReadOnlyList<string> segments,
+        int index,
+        object value
+    )
+    {
+        if (current == null)
+            throw new InvalidOperationException(
+                $"Cannot traverse null while setting '{string.Join(".", segments)}'."
+            );
+        var member = FindMember(current.GetType(), segments[index]);
+        if (member == null)
+            throw new MissingMemberException(
+                current.GetType().FullName,
+                segments[index]
+            );
+        var memberType = GetMemberType(member);
+        if (index == segments.Count - 1)
+        {
+            var converted = ConvertForType(value, memberType);
+            SetMemberValue(member, current, converted);
+            return current;
+        }
+
+        var child = GetMemberValue(member, current);
+        var updatedChild = SetMemberRecursive(
+            child,
+            segments,
+            index + 1,
+            value
+        );
+        if (memberType.IsValueType)
+            SetMemberValue(member, current, updatedChild);
+        return current;
+    }
+
+    private static MemberInfo FindMember(Type type, string name)
+    {
+        const BindingFlags flags =
+            BindingFlags.Instance
+            | BindingFlags.Public
+            | BindingFlags.NonPublic;
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            var field = current.GetField(name, flags);
+            if (field != null)
+                return field;
+            var property = current.GetProperty(name, flags);
+            if (property != null && property.CanRead && property.CanWrite)
+                return property;
+        }
+
+        return null;
+    }
+
+    private static Type GetMemberType(MemberInfo member) =>
+        member is FieldInfo field
+            ? field.FieldType
+            : ((PropertyInfo)member).PropertyType;
+
+    private static object GetMemberValue(MemberInfo member, object target) =>
+        member is FieldInfo field
+            ? field.GetValue(target)
+            : ((PropertyInfo)member).GetValue(target);
+
+    private static void SetMemberValue(
+        MemberInfo member,
+        object target,
+        object value
+    )
+    {
+        if (member is FieldInfo field)
+            field.SetValue(target, value);
+        else
+            ((PropertyInfo)member).SetValue(target, value);
+    }
+
+    private static object ConvertForType(object value, Type targetType)
+    {
+        if (value == null || targetType.IsInstanceOfType(value))
+            return value;
+        if (targetType.IsEnum)
+            return Enum.ToObject(targetType, value);
+        return Convert.ChangeType(
+            value,
+            targetType,
+            CultureInfo.InvariantCulture
+        );
+    }
+
+    private static object ConvertValue(PrefabPatchValue value) =>
+        value.Kind switch
+        {
+            PrefabPatchValueKind.Boolean => value.Boolean,
+            PrefabPatchValueKind.Integer => value.Integer,
+            PrefabPatchValueKind.Float => value.Float,
+            PrefabPatchValueKind.String => value.String,
+            PrefabPatchValueKind.Vector2 =>
+                new Vector2((float)value.X, (float)value.Y),
+            PrefabPatchValueKind.Vector3 =>
+                new Vector3((float)value.X, (float)value.Y, (float)value.Z),
+            PrefabPatchValueKind.Vector4 =>
+                new Vector4(
+                    (float)value.X,
+                    (float)value.Y,
+                    (float)value.Z,
+                    (float)value.W
+                ),
+            PrefabPatchValueKind.Quaternion =>
+                new Quaternion(
+                    (float)value.X,
+                    (float)value.Y,
+                    (float)value.Z,
+                    (float)value.W
+                ),
+            PrefabPatchValueKind.Color =>
+                new Color(
+                    (float)value.X,
+                    (float)value.Y,
+                    (float)value.Z,
+                    (float)value.W
+                ),
+            _ => throw new NotSupportedException(
+                $"Typed value kind '{value.Kind}' is unsupported."
+            )
+        };
+
+    private static Vector3 ToVector3(
+        PrefabPatchValue value,
+        Vector3 fallback
+    ) =>
+        value == null
+            ? fallback
+            : new Vector3((float)value.X, (float)value.Y, (float)value.Z);
+
+    private static Quaternion ToQuaternion(
+        PrefabPatchValue value,
+        Quaternion fallback
+    ) =>
+        value == null
+            ? fallback
+            : new Quaternion(
+                (float)value.X,
+                (float)value.Y,
+                (float)value.Z,
+                (float)value.W
+            );
+
+    private static void SetVectorComponent(
+        ref Vector3 value,
+        string component,
+        float replacement
+    )
+    {
+        switch (component)
+        {
+            case "x":
+                value.x = replacement;
+                break;
+            case "y":
+                value.y = replacement;
+                break;
+            case "z":
+                value.z = replacement;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(component));
+        }
+    }
+
+    private static void SetQuaternionComponent(
+        ref Quaternion value,
+        string component,
+        float replacement
+    )
+    {
+        switch (component)
+        {
+            case "x":
+                value.x = replacement;
+                break;
+            case "y":
+                value.y = replacement;
+                break;
+            case "z":
+                value.z = replacement;
+                break;
+            case "w":
+                value.w = replacement;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(component));
+        }
+    }
+
+    private static GameObject AsGameObject(Object target) =>
+        target switch
+        {
+            GameObject gameObject => gameObject,
+            Component component => component.gameObject,
+            _ => null
+        };
+
+    private static Type ResolveType(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+        var type = Type.GetType(name, false);
+        if (type != null)
+            return type;
+        return AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Select(assembly => assembly.GetType(name, false))
+            .FirstOrDefault(value => value != null);
+    }
+
+    private static Exception MissingTarget(PrefabPatchOperation operation) =>
+        new InvalidOperationException(
+            $"Operation '{operation.OperationId}' from '{operation.PatchId}' "
+                + $"could not resolve target '{operation.Target?.CanonicalKey}'."
+        );
+}

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Newtonsoft.Json;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -15,6 +17,28 @@ namespace PatchManager.PrefabPatching;
 /// </summary>
 public static class PrefabPatchComposer
 {
+    private sealed class PendingReference
+    {
+        public Object Target;
+        public string PropertyPath;
+        public PrefabPatchObjectReference Reference;
+        public string OperationId;
+    }
+
+    private sealed class AnimationCurvePayload
+    {
+        public Keyframe[] Keys;
+        public int PreWrapMode;
+        public int PostWrapMode;
+    }
+
+    private sealed class GradientPayload
+    {
+        public GradientColorKey[] ColorKeys;
+        public GradientAlphaKey[] AlphaKeys;
+        public int Mode;
+    }
+
     public sealed class Result
     {
         public bool Success;
@@ -22,6 +46,9 @@ public static class PrefabPatchComposer
         public long ElapsedMilliseconds;
         public int AppliedOperationCount;
         public Dictionary<string, GameObject> PatchOwnedObjects = new(
+            StringComparer.Ordinal
+        );
+        public Dictionary<string, Component> PatchOwnedComponents = new(
             StringComparer.Ordinal
         );
     }
@@ -34,6 +61,9 @@ public static class PrefabPatchComposer
     {
         var stopwatch = Stopwatch.StartNew();
         var result = new Result();
+        Transform originalParent = null;
+        var originalSiblingIndex = 0;
+        GameObject safetyRoot = null;
         try
         {
             if (prefab == null)
@@ -63,7 +93,19 @@ public static class PrefabPatchComposer
                 );
             }
 
+            if (prefab.activeInHierarchy)
+            {
+                originalParent = prefab.transform.parent;
+                originalSiblingIndex = prefab.transform.GetSiblingIndex();
+                safetyRoot = new GameObject(
+                    "PatchManager Composition Root"
+                );
+                safetyRoot.hideFlags = HideFlags.HideAndDontSave;
+                safetyRoot.SetActive(false);
+                prefab.transform.SetParent(safetyRoot.transform, false);
+            }
             var unusedDeferredDestroy = false;
+            var pendingReferences = new List<PendingReference>();
             foreach (var operation in plan.Operations)
             {
                 ApplyOne(
@@ -71,10 +113,37 @@ public static class PrefabPatchComposer
                     operation,
                     references,
                     result.PatchOwnedObjects,
+                    result.PatchOwnedComponents,
+                    pendingReferences,
                     ref unusedDeferredDestroy,
                     true
                 );
                 result.AppliedOperationCount++;
+            }
+
+            foreach (var pending in pendingReferences)
+            {
+                var reference = ResolveReference(
+                    prefab,
+                    pending.Reference,
+                    references,
+                    result.PatchOwnedObjects,
+                    result.PatchOwnedComponents
+                );
+                if (reference == null && pending.Reference != null)
+                {
+                    throw new InvalidOperationException(
+                        $"Operation '{pending.OperationId}' could not resolve "
+                            + $"object reference "
+                            + $"'{DescribeReference(pending.Reference)}'."
+                    );
+                }
+
+                SetRawValue(
+                    pending.Target,
+                    pending.PropertyPath,
+                    reference
+                );
             }
 
             result.Success = true;
@@ -85,6 +154,16 @@ public static class PrefabPatchComposer
         }
         finally
         {
+            if (safetyRoot != null)
+            {
+                if (prefab != null)
+                {
+                    prefab.transform.SetParent(originalParent, false);
+                    if (originalParent != null)
+                        prefab.transform.SetSiblingIndex(originalSiblingIndex);
+                }
+                Object.DestroyImmediate(safetyRoot);
+            }
             stopwatch.Stop();
             result.ElapsedMilliseconds = stopwatch.ElapsedMilliseconds;
         }
@@ -97,6 +176,8 @@ public static class PrefabPatchComposer
         PrefabPatchOperation operation,
         IReadOnlyDictionary<string, Object> references,
         IDictionary<string, GameObject> patchOwned,
+        IDictionary<string, Component> patchComponents,
+        ICollection<PendingReference> pendingReferences,
         ref bool deferredDestroy,
         bool immediateDestroy
     )
@@ -105,7 +186,14 @@ public static class PrefabPatchComposer
         {
             var parentObject = operation.Target == null
                 ? root
-                : AsGameObject(Resolve(root, operation.Target, patchOwned));
+                : AsGameObject(
+                    Resolve(
+                        root,
+                        operation.Target,
+                        patchOwned,
+                        patchComponents
+                    )
+                );
             if (parentObject == null)
                 throw MissingTarget(operation);
             CreateFragment(
@@ -113,12 +201,20 @@ public static class PrefabPatchComposer
                 operation.AddedObject,
                 parentObject.transform,
                 references,
-                patchOwned
+                patchOwned,
+                patchComponents,
+                pendingReferences,
+                operation.OperationId
             );
             return;
         }
 
-        var target = Resolve(root, operation.Target, patchOwned);
+        var target = Resolve(
+            root,
+            operation.Target,
+            patchOwned,
+            patchComponents
+        );
         if (target == null)
             throw MissingTarget(operation);
         switch (operation.Kind)
@@ -127,23 +223,20 @@ public static class PrefabPatchComposer
                 SetValue(target, operation.PropertyPath, operation.Value);
                 return;
             case PrefabPatchOperationKind.SetObjectReference:
-                if (
-                    operation.ObjectReference == null
-                    || !references.TryGetValue(
-                        operation.ObjectReference.Address,
-                        out var reference
-                    )
-                    || reference == null
-                )
-                {
+                if (operation.ObjectReference == null)
                     throw new InvalidOperationException(
-                        $"Operation '{operation.OperationId}' could not resolve "
-                            + $"object reference "
-                            + $"'{operation.ObjectReference?.Address}'."
+                        $"Operation '{operation.OperationId}' has no object "
+                            + "reference payload."
                     );
-                }
-
-                SetRawValue(target, operation.PropertyPath, reference);
+                pendingReferences.Add(
+                    new PendingReference
+                    {
+                        Target = target,
+                        PropertyPath = operation.PropertyPath,
+                        Reference = operation.ObjectReference,
+                        OperationId = operation.OperationId
+                    }
+                );
                 return;
             case PrefabPatchOperationKind.SetActive:
                 AsGameObject(target)?.SetActive(
@@ -157,7 +250,12 @@ public static class PrefabPatchComposer
                 AddComponent(
                     AsGameObject(target),
                     operation.AddedComponent,
-                    references
+                    references,
+                    patchOwned,
+                    patchComponents,
+                    pendingReferences,
+                    operation.PatchId,
+                    operation.OperationId
                 );
                 return;
             case PrefabPatchOperationKind.RemoveComponent:
@@ -200,9 +298,22 @@ public static class PrefabPatchComposer
     private static Object Resolve(
         GameObject root,
         PrefabPatchObjectTarget target,
-        IDictionary<string, GameObject> patchOwned
+        IDictionary<string, GameObject> patchOwned,
+        IDictionary<string, Component> patchComponents
     )
     {
+        if (target.Kind == PrefabPatchTargetKind.PatchComponent)
+        {
+            var componentKey =
+                $"{target.OwnerPatchId}:{target.ComponentId}";
+            return patchComponents.TryGetValue(
+                componentKey,
+                out var patchComponent
+            )
+                ? patchComponent
+                : null;
+        }
+
         Transform transform;
         if (target.Kind == PrefabPatchTargetKind.Stock)
         {
@@ -245,7 +356,10 @@ public static class PrefabPatchComposer
         PrefabPatchObjectFragment fragment,
         Transform parent,
         IReadOnlyDictionary<string, Object> references,
-        IDictionary<string, GameObject> patchOwned
+        IDictionary<string, GameObject> patchOwned,
+        IDictionary<string, Component> patchComponents,
+        ICollection<PendingReference> pendingReferences,
+        string operationId
     )
     {
         if (fragment == null || string.IsNullOrWhiteSpace(fragment.ObjectId))
@@ -258,8 +372,33 @@ public static class PrefabPatchComposer
                 $"Patch-owned object '{key}' already exists."
             );
 
-        var gameObject = new GameObject(fragment.Name ?? fragment.ObjectId);
+        var transformType = ResolveType(fragment.TransformType);
+        var gameObject =
+            transformType != null
+            && typeof(RectTransform).IsAssignableFrom(transformType)
+                ? new GameObject(
+                    fragment.Name ?? fragment.ObjectId,
+                    typeof(RectTransform)
+                )
+                : new GameObject(fragment.Name ?? fragment.ObjectId);
         gameObject.transform.SetParent(parent, false);
+        gameObject.layer = fragment.Layer;
+        if (!string.IsNullOrWhiteSpace(fragment.Tag))
+        {
+            try
+            {
+                gameObject.tag = fragment.Tag;
+            }
+            catch (UnityException exception)
+            {
+                throw new InvalidOperationException(
+                    $"Patch-owned object '{key}' uses unknown tag "
+                        + $"'{fragment.Tag}'.",
+                    exception
+                );
+            }
+        }
+        gameObject.isStatic = fragment.IsStatic;
         gameObject.transform.localPosition = ToVector3(
             fragment.LocalPosition,
             Vector3.zero
@@ -272,78 +411,199 @@ public static class PrefabPatchComposer
             fragment.LocalScale,
             Vector3.one
         );
+        if (gameObject.transform is RectTransform rectTransform)
+        {
+            rectTransform.anchorMin = ToVector2(
+                fragment.AnchorMin,
+                rectTransform.anchorMin
+            );
+            rectTransform.anchorMax = ToVector2(
+                fragment.AnchorMax,
+                rectTransform.anchorMax
+            );
+            rectTransform.anchoredPosition = ToVector2(
+                fragment.AnchoredPosition,
+                rectTransform.anchoredPosition
+            );
+            rectTransform.sizeDelta = ToVector2(
+                fragment.SizeDelta,
+                rectTransform.sizeDelta
+            );
+            rectTransform.pivot = ToVector2(
+                fragment.Pivot,
+                rectTransform.pivot
+            );
+        }
         gameObject.SetActive(fragment.Active);
         gameObject.AddComponent<PrefabPatchObjectId>().Id = fragment.ObjectId;
         patchOwned.Add(key, gameObject);
         foreach (var component in fragment.Components)
-            AddComponent(gameObject, component, references);
+            AddComponent(
+                gameObject,
+                component,
+                references,
+                patchOwned,
+                patchComponents,
+                pendingReferences,
+                patchId,
+                operationId
+            );
         foreach (var child in fragment.Children)
-            CreateFragment(patchId, child, gameObject.transform, references, patchOwned);
+            CreateFragment(
+                patchId,
+                child,
+                gameObject.transform,
+                references,
+                patchOwned,
+                patchComponents,
+                pendingReferences,
+                operationId
+            );
         return gameObject;
     }
 
     private static Component AddComponent(
         GameObject target,
         PrefabPatchComponentFragment fragment,
-        IReadOnlyDictionary<string, Object> references
+        IReadOnlyDictionary<string, Object> references,
+        IDictionary<string, GameObject> patchOwned,
+        IDictionary<string, Component> patchComponents,
+        ICollection<PendingReference> pendingReferences,
+        string patchId,
+        string operationId
     )
     {
         if (target == null || fragment == null)
             throw new InvalidOperationException(
                 "An added component has no target or payload."
             );
-        switch (fragment.Kind)
+        if (string.IsNullOrWhiteSpace(fragment.ComponentType))
+            throw new InvalidOperationException(
+                "An added component has no assembly-qualified component type."
+            );
+        var type = ResolveType(fragment.ComponentType);
+        if (type == null || !typeof(Component).IsAssignableFrom(type))
         {
-            case PrefabPatchComponentKind.BoxCollider:
-            {
-                var value = target.AddComponent<BoxCollider>();
-                value.enabled = fragment.Enabled;
-                value.center = ToVector3(fragment.Center, Vector3.zero);
-                value.size = ToVector3(fragment.Size, Vector3.one);
-                value.isTrigger = fragment.IsTrigger;
-                return value;
-            }
-            case PrefabPatchComponentKind.SphereCollider:
-            {
-                var value = target.AddComponent<SphereCollider>();
-                value.enabled = fragment.Enabled;
-                value.center = ToVector3(fragment.Center, Vector3.zero);
-                value.radius = (float)fragment.Radius;
-                value.isTrigger = fragment.IsTrigger;
-                return value;
-            }
-            case PrefabPatchComponentKind.MeshFilter:
-            {
-                var value = target.AddComponent<MeshFilter>();
-                if (fragment.Mesh != null)
+            throw new InvalidOperationException(
+                $"Added component type '{fragment.ComponentType}' could "
+                    + "not be resolved as a Unity Component."
+            );
+        }
+        if (typeof(Transform).IsAssignableFrom(type))
+        {
+            throw new InvalidOperationException(
+                $"Transform type '{fragment.ComponentType}' must be "
+                    + "declared by the object fragment, not added as a "
+                    + "component."
+            );
+        }
+
+        var component = target.AddComponent(type);
+        foreach (var value in fragment.Values ?? new())
+        {
+            if (
+                value == null
+                || string.IsNullOrWhiteSpace(value.PropertyPath)
+            )
+                continue;
+            SetValue(component, value.PropertyPath, value.Value);
+        }
+        QueueComponentReferences(
+            component,
+            fragment,
+            pendingReferences,
+            operationId
+        );
+        RegisterPatchComponent(
+            patchId,
+            fragment,
+            component,
+            patchComponents
+        );
+        return component;
+    }
+
+    private static void QueueComponentReferences(
+        Component component,
+        PrefabPatchComponentFragment fragment,
+        ICollection<PendingReference> pendingReferences,
+        string operationId
+    )
+    {
+        foreach (var reference in fragment.References ?? new())
+        {
+            if (
+                reference == null
+                || string.IsNullOrWhiteSpace(reference.PropertyPath)
+            )
+                continue;
+            pendingReferences.Add(
+                new PendingReference
                 {
-                    if (
-                        !references.TryGetValue(
-                            fragment.Mesh.Address,
-                            out var reference
-                        )
-                        || reference is not Mesh mesh
-                    )
-                    {
-                        throw new InvalidOperationException(
-                            $"Could not resolve Mesh reference "
-                                + $"'{fragment.Mesh.Address}'."
-                        );
-                    }
-
-                    value.sharedMesh = mesh;
+                    Target = component,
+                    PropertyPath = reference.PropertyPath,
+                    Reference = reference.Reference,
+                    OperationId = operationId
                 }
-
-                return value;
-            }
-            case PrefabPatchComponentKind.MeshRenderer:
-                return target.AddComponent<MeshRenderer>();
-            default:
-                throw new NotSupportedException(
-                    $"Added component kind '{fragment.Kind}' is unsupported."
-                );
+            );
         }
     }
+
+    private static void RegisterPatchComponent(
+        string patchId,
+        PrefabPatchComponentFragment fragment,
+        Component component,
+        IDictionary<string, Component> patchComponents
+    )
+    {
+        if (string.IsNullOrWhiteSpace(fragment.ComponentId))
+            return;
+        var key = $"{patchId}:{fragment.ComponentId}";
+        if (patchComponents.ContainsKey(key))
+            throw new InvalidOperationException(
+                $"Patch-owned component '{key}' already exists."
+            );
+        patchComponents.Add(key, component);
+    }
+
+    private static Object ResolveReference(
+        GameObject root,
+        PrefabPatchObjectReference reference,
+        IReadOnlyDictionary<string, Object> references,
+        IDictionary<string, GameObject> patchOwned,
+        IDictionary<string, Component> patchComponents
+    )
+    {
+        if (reference == null)
+            return null;
+        if (
+            reference.Kind == PrefabPatchObjectReferenceKind.Target
+            || reference.Target != null
+        )
+        {
+            return Resolve(
+                root,
+                reference.Target,
+                patchOwned,
+                patchComponents
+            );
+        }
+
+        return !string.IsNullOrWhiteSpace(reference.Address)
+            && references.TryGetValue(reference.Address, out var value)
+                ? value
+                : null;
+    }
+
+    private static string DescribeReference(
+        PrefabPatchObjectReference reference
+    ) =>
+        reference == null
+            ? "<null>"
+            : reference.Kind == PrefabPatchObjectReferenceKind.Target
+                || reference.Target != null
+                ? reference.Target?.CanonicalKey ?? "<missing-target>"
+                : reference.Address ?? "<missing-address>";
 
     private static void SetValue(
         Object target,
@@ -355,6 +615,15 @@ public static class PrefabPatchComposer
             throw new InvalidOperationException(
                 $"Property '{propertyPath}' has no typed value."
             );
+        if (value.Kind == PrefabPatchValueKind.ArraySize)
+        {
+            SetCollectionSize(
+                target,
+                propertyPath,
+                checked((int)value.Integer)
+            );
+            return;
+        }
         SetRawValue(target, propertyPath, ConvertValue(value));
     }
 
@@ -544,28 +813,280 @@ public static class PrefabPatchComposer
         object value
     )
     {
-        var segments = path.Split('.');
+        var segments = ParsePath(path);
         SetMemberRecursive(root, segments, 0, value);
+    }
+
+    private static void SetCollectionSize(
+        object root,
+        string propertyPath,
+        int size
+    )
+    {
+        const string suffix = ".Array.size";
+        if (
+            string.IsNullOrWhiteSpace(propertyPath)
+            || !propertyPath.EndsWith(suffix, StringComparison.Ordinal)
+        )
+        {
+            throw new InvalidOperationException(
+                $"Collection-size path '{propertyPath}' does not end in "
+                    + $"'{suffix}'."
+            );
+        }
+        if (size < 0)
+            throw new ArgumentOutOfRangeException(nameof(size));
+        var collectionPath = propertyPath.Substring(
+            0,
+            propertyPath.Length - suffix.Length
+        );
+        ResizeCollectionRecursive(
+            root,
+            ParsePath(collectionPath),
+            0,
+            size
+        );
+    }
+
+    private static object ResizeCollectionRecursive(
+        object current,
+        IReadOnlyList<MemberPathSegment> segments,
+        int index,
+        int size
+    )
+    {
+        if (current == null)
+            throw new InvalidOperationException(
+                "Cannot resize a collection through a null serialized value."
+            );
+        var segment = segments[index];
+        var member = FindMember(current.GetType(), segment.Name)
+            ?? throw new MissingMemberException(
+                current.GetType().FullName,
+                segment.Name
+            );
+        var memberType = GetMemberType(member);
+        var memberValue = GetMemberValue(member, current);
+        if (segment.HasIndex)
+        {
+            if (memberValue is not IList list)
+                throw new InvalidOperationException(
+                    $"Member '{segment.Name}' is not an indexed collection."
+                );
+            var element = list[segment.Index];
+            var updated = ResizeCollectionRecursive(
+                element,
+                segments,
+                index + 1,
+                size
+            );
+            var elementType = GetCollectionElementType(memberType);
+            if (elementType.IsValueType)
+                list[segment.Index] = updated;
+            return current;
+        }
+
+        if (index < segments.Count - 1)
+        {
+            var updated = ResizeCollectionRecursive(
+                memberValue,
+                segments,
+                index + 1,
+                size
+            );
+            if (memberType.IsValueType)
+                SetMemberValue(member, current, updated);
+            return current;
+        }
+
+        if (memberType.IsArray)
+        {
+            var elementType =
+                memberType.GetElementType() ?? typeof(object);
+            var previous = memberValue as Array;
+            var replacement = Array.CreateInstance(elementType, size);
+            if (previous != null)
+            {
+                Array.Copy(
+                    previous,
+                    replacement,
+                    Math.Min(previous.Length, size)
+                );
+            }
+            for (
+                var itemIndex = previous?.Length ?? 0;
+                itemIndex < size;
+                itemIndex++
+            )
+            {
+                replacement.SetValue(
+                    CreateCollectionElement(elementType),
+                    itemIndex
+                );
+            }
+            SetMemberValue(member, current, replacement);
+            return current;
+        }
+
+        if (memberValue is not IList mutableList)
+        {
+            if (
+                memberType.IsInterface
+                || memberType.IsAbstract
+            )
+            {
+                throw new InvalidOperationException(
+                    $"Collection member '{segment.Name}' of type "
+                        + $"'{memberType.FullName}' is null and cannot be "
+                        + "constructed."
+                );
+            }
+            mutableList = (IList)Activator.CreateInstance(memberType);
+            SetMemberValue(member, current, mutableList);
+        }
+        var itemType = GetCollectionElementType(memberType);
+        while (mutableList.Count > size)
+            mutableList.RemoveAt(mutableList.Count - 1);
+        while (mutableList.Count < size)
+            mutableList.Add(CreateCollectionElement(itemType));
+        return current;
+    }
+
+    private static object CreateCollectionElement(Type itemType)
+    {
+        if (
+            itemType == typeof(string)
+            || itemType.IsAbstract
+            || itemType.IsInterface
+        )
+            return null;
+        try
+        {
+            return Activator.CreateInstance(itemType);
+        }
+        catch (MissingMethodException)
+        {
+            return System.Runtime.Serialization.FormatterServices
+                .GetUninitializedObject(itemType);
+        }
+    }
+
+    private readonly struct MemberPathSegment
+    {
+        public readonly string Name;
+        public readonly int Index;
+        public readonly bool HasIndex;
+
+        public MemberPathSegment(string name, int index, bool hasIndex)
+        {
+            Name = name;
+            Index = index;
+            HasIndex = hasIndex;
+        }
+
+        public override string ToString() =>
+            HasIndex ? $"{Name}[{Index}]" : Name;
+    }
+
+    private static IReadOnlyList<MemberPathSegment> ParsePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException(
+                "A serialized property path is required.",
+                nameof(path)
+            );
+        var normalized = path.Replace(".Array.data[", "[");
+        var result = new List<MemberPathSegment>();
+        foreach (var raw in normalized.Split('.'))
+        {
+            var bracket = raw.LastIndexOf('[');
+            if (
+                bracket > 0
+                && raw.EndsWith("]", StringComparison.Ordinal)
+                && int.TryParse(
+                    raw.Substring(bracket + 1, raw.Length - bracket - 2),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var index
+                )
+            )
+            {
+                result.Add(
+                    new MemberPathSegment(
+                        raw.Substring(0, bracket),
+                        index,
+                        true
+                    )
+                );
+            }
+            else
+            {
+                result.Add(new MemberPathSegment(raw, 0, false));
+            }
+        }
+
+        return result;
     }
 
     private static object SetMemberRecursive(
         object current,
-        IReadOnlyList<string> segments,
+        IReadOnlyList<MemberPathSegment> segments,
         int index,
         object value
     )
     {
         if (current == null)
             throw new InvalidOperationException(
-                $"Cannot traverse null while setting '{string.Join(".", segments)}'."
+                $"Cannot traverse null while setting "
+                    + $"'{string.Join(".", segments)}'."
             );
-        var member = FindMember(current.GetType(), segments[index]);
+        var segment = segments[index];
+        var member = FindMember(current.GetType(), segment.Name);
         if (member == null)
             throw new MissingMemberException(
                 current.GetType().FullName,
-                segments[index]
+                segment.Name
             );
         var memberType = GetMemberType(member);
+        var memberValue = GetMemberValue(member, current);
+        if (segment.HasIndex)
+        {
+            if (memberValue is not IList list)
+            {
+                throw new InvalidOperationException(
+                    $"Member '{segment.Name}' on "
+                        + $"'{current.GetType().FullName}' is not an indexed "
+                        + "serialized collection."
+                );
+            }
+            if (segment.Index < 0 || segment.Index >= list.Count)
+            {
+                throw new IndexOutOfRangeException(
+                    $"Serialized collection '{segment.Name}' has "
+                        + $"{list.Count} item(s), but index {segment.Index} "
+                        + "was requested."
+                );
+            }
+
+            var elementType = GetCollectionElementType(memberType);
+            if (index == segments.Count - 1)
+            {
+                list[segment.Index] = ConvertForType(value, elementType);
+                return current;
+            }
+
+            var element = list[segment.Index];
+            var updatedElement = SetMemberRecursive(
+                element,
+                segments,
+                index + 1,
+                value
+            );
+            if (elementType.IsValueType)
+                list[segment.Index] = updatedElement;
+            return current;
+        }
+
         if (index == segments.Count - 1)
         {
             var converted = ConvertForType(value, memberType);
@@ -573,9 +1094,8 @@ public static class PrefabPatchComposer
             return current;
         }
 
-        var child = GetMemberValue(member, current);
         var updatedChild = SetMemberRecursive(
-            child,
+            memberValue,
             segments,
             index + 1,
             value
@@ -583,6 +1103,15 @@ public static class PrefabPatchComposer
         if (memberType.IsValueType)
             SetMemberValue(member, current, updatedChild);
         return current;
+    }
+
+    private static Type GetCollectionElementType(Type collectionType)
+    {
+        if (collectionType.IsArray)
+            return collectionType.GetElementType() ?? typeof(object);
+        if (collectionType.IsGenericType)
+            return collectionType.GetGenericArguments()[0];
+        return typeof(object);
     }
 
     private static MemberInfo FindMember(Type type, string name)
@@ -599,6 +1128,36 @@ public static class PrefabPatchComposer
             var property = current.GetProperty(name, flags);
             if (property != null && property.CanRead && property.CanWrite)
                 return property;
+        }
+
+        if (
+            name.StartsWith("m_", StringComparison.Ordinal)
+            && name.Length > 2
+        )
+        {
+            var serializedName =
+                char.ToLowerInvariant(name[2]) + name.Substring(3);
+            var property = type.GetProperty(serializedName, flags);
+            if (property != null && property.CanRead && property.CanWrite)
+                return property;
+
+            var alias = name switch
+            {
+                "m_Mesh" => "sharedMesh",
+                "m_Material" => "sharedMaterial",
+                "m_Materials" => "sharedMaterials",
+                _ => null
+            };
+            if (alias != null)
+            {
+                property = type.GetProperty(alias, flags);
+                if (
+                    property != null
+                    && property.CanRead
+                    && property.CanWrite
+                )
+                    return property;
+            }
         }
 
         return null;
@@ -628,6 +1187,34 @@ public static class PrefabPatchComposer
 
     private static object ConvertForType(object value, Type targetType)
     {
+        if (value is PrefabPatchValue patchValue)
+        {
+            if (
+                patchValue.Kind
+                == PrefabPatchValueKind.ManagedReference
+            )
+            {
+                var concreteType = ResolveType(
+                    patchValue.SerializedType
+                );
+                if (
+                    concreteType == null
+                    || !targetType.IsAssignableFrom(concreteType)
+                )
+                {
+                    throw new InvalidOperationException(
+                        $"Managed-reference type "
+                            + $"'{patchValue.SerializedType}' is not "
+                            + $"assignable to '{targetType.FullName}'."
+                    );
+                }
+                return CreateCollectionElement(concreteType);
+            }
+            if (patchValue.Kind != PrefabPatchValueKind.Json)
+                value = ConvertValue(patchValue);
+            else
+                return DeserializeJsonValue(patchValue, targetType);
+        }
         if (value == null || targetType.IsInstanceOfType(value))
             return value;
         if (targetType.IsEnum)
@@ -636,6 +1223,56 @@ public static class PrefabPatchComposer
             value,
             targetType,
             CultureInfo.InvariantCulture
+        );
+    }
+
+    private static object DeserializeJsonValue(
+        PrefabPatchValue value,
+        Type targetType
+    )
+    {
+        if (targetType == typeof(AnimationCurve))
+        {
+            var payload = JsonConvert.DeserializeObject<
+                AnimationCurvePayload
+            >(value.String, PrefabPatchJson.Settings);
+            var curve = new AnimationCurve(
+                payload?.Keys ?? Array.Empty<Keyframe>()
+            )
+            {
+                preWrapMode =
+                    (WrapMode)(payload?.PreWrapMode ?? (int)WrapMode.Default),
+                postWrapMode =
+                    (WrapMode)(payload?.PostWrapMode ?? (int)WrapMode.Default)
+            };
+            return curve;
+        }
+        if (targetType == typeof(Gradient))
+        {
+            var payload = JsonConvert.DeserializeObject<GradientPayload>(
+                value.String,
+                PrefabPatchJson.Settings
+            );
+            var gradient = new Gradient
+            {
+                mode = (GradientMode)(
+                    payload?.Mode ?? (int)GradientMode.Blend
+                )
+            };
+            gradient.SetKeys(
+                payload?.ColorKeys ?? Array.Empty<GradientColorKey>(),
+                payload?.AlphaKeys ?? Array.Empty<GradientAlphaKey>()
+            );
+            return gradient;
+        }
+        if (targetType == typeof(Hash128))
+            return Hash128.Parse(
+                JsonConvert.DeserializeObject<string>(value.String)
+            );
+        return JsonConvert.DeserializeObject(
+            value.String ?? "null",
+            targetType,
+            PrefabPatchJson.Settings
         );
     }
 
@@ -671,6 +1308,7 @@ public static class PrefabPatchComposer
                     (float)value.Z,
                     (float)value.W
                 ),
+            PrefabPatchValueKind.Json => value,
             _ => throw new NotSupportedException(
                 $"Typed value kind '{value.Kind}' is unsupported."
             )
@@ -683,6 +1321,14 @@ public static class PrefabPatchComposer
         value == null
             ? fallback
             : new Vector3((float)value.X, (float)value.Y, (float)value.Z);
+
+    private static Vector2 ToVector2(
+        PrefabPatchValue value,
+        Vector2 fallback
+    ) =>
+        value == null
+            ? fallback
+            : new Vector2((float)value.X, (float)value.Y);
 
     private static Quaternion ToQuaternion(
         PrefabPatchValue value,

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs
@@ -88,9 +88,7 @@ public static class PrefabPatchComposer
                     $"Stock prefab '{plan.TargetPrefab.Address}' structural "
                         + $"fingerprint changed. Expected "
                         + $"'{plan.TargetPrefab.StructuralFingerprint}', got "
-                        + $"'{actualFingerprint}'. Expected structure: "
-                        + $"'{plan.TargetPrefab.StructuralDescription}'. "
-                        + $"Actual structure: "
+                        + $"'{actualFingerprint}'. Actual structure: "
                         + $"'{PrefabPatchStructure.Describe(prefab)}'. "
                         + "Recompile or repair the patch."
                 );

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs
@@ -383,6 +383,19 @@ public static class PrefabPatchComposer
         if (segments.Length != 2)
             return false;
         var component = Convert.ToSingle(value, CultureInfo.InvariantCulture);
+        if (
+            transform is RectTransform rectTransform
+            && TrySetRectTransform(
+                rectTransform,
+                segments[0],
+                segments[1],
+                component
+            )
+        )
+        {
+            return true;
+        }
+
         switch (segments[0])
         {
             case "m_LocalPosition":
@@ -415,6 +428,101 @@ public static class PrefabPatchComposer
             }
             default:
                 return false;
+        }
+    }
+
+    private static bool TrySetRectTransform(
+        RectTransform transform,
+        string property,
+        string componentName,
+        float componentValue
+    )
+    {
+        switch (property)
+        {
+            case "m_AnchoredPosition":
+            case "anchoredPosition":
+            {
+                var value = transform.anchoredPosition;
+                SetVector2Component(
+                    ref value,
+                    componentName,
+                    componentValue
+                );
+                transform.anchoredPosition = value;
+                return true;
+            }
+            case "m_SizeDelta":
+            case "sizeDelta":
+            {
+                var value = transform.sizeDelta;
+                SetVector2Component(
+                    ref value,
+                    componentName,
+                    componentValue
+                );
+                transform.sizeDelta = value;
+                return true;
+            }
+            case "m_AnchorMin":
+            case "anchorMin":
+            {
+                var value = transform.anchorMin;
+                SetVector2Component(
+                    ref value,
+                    componentName,
+                    componentValue
+                );
+                transform.anchorMin = value;
+                return true;
+            }
+            case "m_AnchorMax":
+            case "anchorMax":
+            {
+                var value = transform.anchorMax;
+                SetVector2Component(
+                    ref value,
+                    componentName,
+                    componentValue
+                );
+                transform.anchorMax = value;
+                return true;
+            }
+            case "m_Pivot":
+            case "pivot":
+            {
+                var value = transform.pivot;
+                SetVector2Component(
+                    ref value,
+                    componentName,
+                    componentValue
+                );
+                transform.pivot = value;
+                return true;
+            }
+            default:
+                return false;
+        }
+    }
+
+    private static void SetVector2Component(
+        ref Vector2 vector,
+        string component,
+        float value
+    )
+    {
+        switch (component)
+        {
+            case "x":
+                vector.x = value;
+                return;
+            case "y":
+                vector.y = value;
+                return;
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown Vector2 component '{component}'."
+                );
         }
     }
 

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs
@@ -170,7 +170,19 @@ public static class PrefabPatchComposer
                 }
 
                 if (immediateDestroy)
+                {
+                    // Runtime composition operates on a session-owned clone,
+                    // never directly on the read-only AssetBundle asset.
                     Object.DestroyImmediate(component);
+                    if (component != null)
+                    {
+                        throw new InvalidOperationException(
+                            $"RemoveComponent operation "
+                                + $"'{operation.OperationId}' did not destroy "
+                                + $"'{operation.Target.ObjectType}'."
+                        );
+                    }
+                }
                 else
                 {
                     Object.Destroy(component);

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs
@@ -74,7 +74,10 @@ public static class PrefabPatchComposer
                 );
             var actualFingerprint = PrefabPatchStructure.Calculate(prefab);
             if (
-                !string.Equals(
+                !string.IsNullOrWhiteSpace(
+                    plan.TargetPrefab.StructuralFingerprint
+                )
+                && !string.Equals(
                     actualFingerprint,
                     plan.TargetPrefab.StructuralFingerprint,
                     StringComparison.Ordinal
@@ -317,10 +320,17 @@ public static class PrefabPatchComposer
         Transform transform;
         if (target.Kind == PrefabPatchTargetKind.Stock)
         {
-            transform = PrefabPatchStructure.Resolve(
-                root.transform,
-                target.RuntimeLocator?.SiblingIndices
-            );
+            transform = !string.IsNullOrWhiteSpace(
+                target.RuntimeLocator?.HierarchyPath
+            )
+                ? PrefabPatchStructure.ResolveHierarchyPath(
+                    root.transform,
+                    target.RuntimeLocator.HierarchyPath
+                )
+                : PrefabPatchStructure.Resolve(
+                    root.transform,
+                    target.RuntimeLocator?.SiblingIndices
+                );
         }
         else
         {

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs
@@ -55,7 +55,11 @@ public static class PrefabPatchComposer
                     $"Stock prefab '{plan.TargetPrefab.Address}' structural "
                         + $"fingerprint changed. Expected "
                         + $"'{plan.TargetPrefab.StructuralFingerprint}', got "
-                        + $"'{actualFingerprint}'. Recompile or repair the patch."
+                        + $"'{actualFingerprint}'. Expected structure: "
+                        + $"'{plan.TargetPrefab.StructuralDescription}'. "
+                        + $"Actual structure: "
+                        + $"'{PrefabPatchStructure.Describe(prefab)}'. "
+                        + "Recompile or repair the patch."
                 );
             }
 

--- a/Runtime/PrefabPatching/PrefabPatchComposer.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchComposer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 233910d5b0c5741478f5b3d1e07ea96f

--- a/Runtime/PrefabPatching/PrefabPatchFragmentBuilder.cs
+++ b/Runtime/PrefabPatching/PrefabPatchFragmentBuilder.cs
@@ -1,0 +1,211 @@
+using System;
+using UnityEngine;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Fluent, type-agnostic C# frontend for one serialized component fragment.
+/// It produces the same public model as visual and Lua authoring.
+/// </summary>
+public sealed class PrefabPatchComponentBuilder
+{
+    private readonly PrefabPatchComponentFragment _fragment;
+
+    public PrefabPatchComponentBuilder(string componentId, Type componentType)
+    {
+        if (string.IsNullOrWhiteSpace(componentId))
+            throw new ArgumentException(
+                "A stable component ID is required.",
+                nameof(componentId)
+            );
+        if (
+            componentType == null
+            || componentType.IsAbstract
+            || !typeof(Component).IsAssignableFrom(componentType)
+            || typeof(Transform).IsAssignableFrom(componentType)
+        )
+        {
+            throw new ArgumentException(
+                "The component type must be a concrete, non-Transform Unity "
+                    + "Component.",
+                nameof(componentType)
+            );
+        }
+
+        _fragment = new PrefabPatchComponentFragment
+        {
+            ComponentId = componentId,
+            ComponentType = componentType.AssemblyQualifiedName
+        };
+    }
+
+    public static PrefabPatchComponentBuilder For<T>(string componentId)
+        where T : Component =>
+        new(componentId, typeof(T));
+
+    public PrefabPatchComponentBuilder Value(
+        string propertyPath,
+        PrefabPatchValue value
+    )
+    {
+        _fragment.Values.Add(
+            new PrefabPatchSerializedValue
+            {
+                PropertyPath = propertyPath,
+                Value = value
+            }
+        );
+        return this;
+    }
+
+    public PrefabPatchComponentBuilder Reference(
+        string propertyPath,
+        PrefabPatchObjectReference reference
+    )
+    {
+        _fragment.References.Add(
+            new PrefabPatchSerializedReference
+            {
+                PropertyPath = propertyPath,
+                Reference = reference
+            }
+        );
+        return this;
+    }
+
+    public PrefabPatchComponentFragment Build() => _fragment;
+}
+
+/// <summary>
+/// Fluent C# frontend for an inline patch-owned hierarchy.
+/// </summary>
+public sealed class PrefabPatchObjectBuilder
+{
+    private readonly PrefabPatchObjectFragment _fragment;
+
+    public PrefabPatchObjectBuilder(string objectId, string name = null)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+            throw new ArgumentException(
+                "A stable object ID is required.",
+                nameof(objectId)
+            );
+        _fragment = new PrefabPatchObjectFragment
+        {
+            ObjectId = objectId,
+            Name = name ?? objectId,
+            TransformType = typeof(Transform).AssemblyQualifiedName,
+            LocalPosition = Vector3Value(Vector3.zero),
+            LocalRotation = QuaternionValue(Quaternion.identity),
+            LocalScale = Vector3Value(Vector3.one)
+        };
+    }
+
+    public PrefabPatchObjectBuilder RectTransform()
+    {
+        _fragment.TransformType = typeof(RectTransform).AssemblyQualifiedName;
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Active(bool value)
+    {
+        _fragment.Active = value;
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Layer(int value)
+    {
+        _fragment.Layer = value;
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Tag(string value)
+    {
+        _fragment.Tag = value;
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Static(bool value = true)
+    {
+        _fragment.IsStatic = value;
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Transform(
+        Vector3 localPosition,
+        Quaternion localRotation,
+        Vector3 localScale
+    )
+    {
+        _fragment.LocalPosition = Vector3Value(localPosition);
+        _fragment.LocalRotation = QuaternionValue(localRotation);
+        _fragment.LocalScale = Vector3Value(localScale);
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Rect(
+        Vector2 anchorMin,
+        Vector2 anchorMax,
+        Vector2 anchoredPosition,
+        Vector2 sizeDelta,
+        Vector2 pivot
+    )
+    {
+        RectTransform();
+        _fragment.AnchorMin = Vector2Value(anchorMin);
+        _fragment.AnchorMax = Vector2Value(anchorMax);
+        _fragment.AnchoredPosition = Vector2Value(anchoredPosition);
+        _fragment.SizeDelta = Vector2Value(sizeDelta);
+        _fragment.Pivot = Vector2Value(pivot);
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Component(
+        PrefabPatchComponentFragment component
+    )
+    {
+        _fragment.Components.Add(
+            component ?? throw new ArgumentNullException(nameof(component))
+        );
+        return this;
+    }
+
+    public PrefabPatchObjectBuilder Child(
+        PrefabPatchObjectFragment child
+    )
+    {
+        _fragment.Children.Add(
+            child ?? throw new ArgumentNullException(nameof(child))
+        );
+        return this;
+    }
+
+    public PrefabPatchObjectFragment Build() => _fragment;
+
+    private static PrefabPatchValue Vector2Value(Vector2 value) =>
+        new()
+        {
+            Kind = PrefabPatchValueKind.Vector2,
+            X = value.x,
+            Y = value.y
+        };
+
+    private static PrefabPatchValue Vector3Value(Vector3 value) =>
+        new()
+        {
+            Kind = PrefabPatchValueKind.Vector3,
+            X = value.x,
+            Y = value.y,
+            Z = value.z
+        };
+
+    private static PrefabPatchValue QuaternionValue(Quaternion value) =>
+        new()
+        {
+            Kind = PrefabPatchValueKind.Quaternion,
+            X = value.x,
+            Y = value.y,
+            Z = value.z,
+            W = value.w
+        };
+}

--- a/Runtime/PrefabPatching/PrefabPatchFragmentBuilder.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchFragmentBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65c3fc4c688b4aa192448f378182005c

--- a/Runtime/PrefabPatching/PrefabPatchJson.cs
+++ b/Runtime/PrefabPatching/PrefabPatchJson.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Canonical JSON and SHA-256 helpers shared by the editor compiler, resolver,
+/// cache, and fluent frontend.
+/// </summary>
+public static class PrefabPatchJson
+{
+    public static readonly JsonSerializerSettings Settings = new()
+    {
+        ContractResolver = new DefaultContractResolver
+        {
+            NamingStrategy = new CamelCaseNamingStrategy()
+        },
+        Formatting = Formatting.Indented,
+        NullValueHandling = NullValueHandling.Ignore,
+        DefaultValueHandling = DefaultValueHandling.Include,
+        Converters = { new StringEnumConverter() }
+    };
+
+    public static string Serialize(object value) =>
+        JsonConvert.SerializeObject(value, Settings);
+
+    public static T Deserialize<T>(string json) =>
+        JsonConvert.DeserializeObject<T>(json, Settings);
+
+    public static string Sha256(string value)
+    {
+        using var algorithm = SHA256.Create();
+        var bytes = algorithm.ComputeHash(Encoding.UTF8.GetBytes(value ?? ""));
+        return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+    }
+
+    public static string CalculateManifestHash(PrefabPatchManifest manifest)
+    {
+        var previous = manifest.ManifestHash;
+        manifest.ManifestHash = null;
+        try
+        {
+            return Sha256(Serialize(manifest));
+        }
+        finally
+        {
+            manifest.ManifestHash = previous;
+        }
+    }
+}

--- a/Runtime/PrefabPatching/PrefabPatchJson.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchJson.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1eac2732f7895b49ae9365e98d46fc9

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs
@@ -83,44 +83,18 @@ public enum PrefabPatchObjectReferenceKind
 }
 
 /// <summary>
-/// Canonical identity and compatibility data for one stock Addressable prefab.
+/// Runtime identity and optional compatibility data for one stock Addressable
+/// prefab.
 /// </summary>
 [Serializable]
 public sealed class PrefabPatchPrefabIdentity
 {
     public string Address;
-    public string CatalogId;
-    public string CatalogHash;
-    public string SourceBundleFileName;
-    public string SourceBundleHash;
-    public string SourceSerializedFileName;
-    public long SourcePathId;
     public string AssetType;
-    public string StructuralDescription;
     public string StructuralFingerprint;
 
     [JsonIgnore]
-    public bool HasCanonicalMetadata =>
-        !string.IsNullOrWhiteSpace(CatalogId)
-        || !string.IsNullOrWhiteSpace(CatalogHash)
-        || !string.IsNullOrWhiteSpace(SourceBundleFileName)
-        || !string.IsNullOrWhiteSpace(SourceBundleHash)
-        || !string.IsNullOrWhiteSpace(SourceSerializedFileName)
-        || SourcePathId != 0
-        || !string.IsNullOrWhiteSpace(StructuralDescription)
-        || !string.IsNullOrWhiteSpace(StructuralFingerprint);
-
-    [JsonIgnore]
-    public bool IsCanonical =>
-        !string.IsNullOrWhiteSpace(SourceSerializedFileName)
-        && SourcePathId != 0
-        && !string.IsNullOrWhiteSpace(StructuralFingerprint);
-
-    [JsonIgnore]
-    public string CanonicalKey =>
-        IsCanonical
-            ? $"{CatalogId}|{SourceSerializedFileName}|{SourcePathId}|{AssetType}"
-            : $"address:{Address}";
+    public string CanonicalKey => $"address:{Address}";
 
     public static PrefabPatchPrefabIdentity FromAddress(string address)
     {
@@ -159,8 +133,6 @@ public sealed class PrefabPatchRuntimeLocator
 public sealed class PrefabPatchObjectTarget
 {
     public PrefabPatchTargetKind Kind;
-    public string SourceSerializedFileName;
-    public long SourcePathId;
     public string ObjectType;
     public string OwnerPatchId;
     public string ObjectId;
@@ -187,8 +159,12 @@ public sealed class PrefabPatchObjectTarget
                     + $"{RuntimeLocator.ComponentType}:"
                     + $"{RuntimeLocator.ComponentOrdinal}";
 
-            return $"stock:{SourceSerializedFileName}:"
-                + $"{SourcePathId}:{ObjectType}";
+            var indices = RuntimeLocator?.SiblingIndices == null
+                ? ""
+                : string.Join(",", RuntimeLocator.SiblingIndices);
+            return $"indices:{indices}:{RuntimeLocator?.TargetKind}:"
+                + $"{RuntimeLocator?.ComponentType}:"
+                + $"{RuntimeLocator?.ComponentOrdinal}";
         }
     }
 }
@@ -226,8 +202,7 @@ public sealed class PrefabPatchValue
 
 /// <summary>
 /// Addressable or target-local Unity object reference used by
-/// SetObjectReference or a component fragment. Source identity is retained for
-/// compatibility diagnostics.
+/// SetObjectReference or a component fragment.
 /// </summary>
 [Serializable]
 public sealed class PrefabPatchObjectReference
@@ -235,10 +210,6 @@ public sealed class PrefabPatchObjectReference
     public PrefabPatchObjectReferenceKind Kind;
     public string Address;
     public string ExpectedType;
-    public string CatalogId;
-    public string SourceBundleFileName;
-    public string SourceSerializedFileName;
-    public long SourcePathId;
     public PrefabPatchObjectTarget Target;
 
     public static PrefabPatchObjectReference FromAddress(

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs
@@ -10,8 +10,8 @@ namespace PatchManager.PrefabPatching;
 /// </summary>
 public static class PrefabPatchSchema
 {
-    public const int Version = 1;
-    public const int ComposerVersion = 1;
+    public const int Version = 2;
+    public const int ComposerVersion = 2;
     public const string AddressablesLabel = "patch-manager-prefab-patches";
 }
 
@@ -35,7 +35,8 @@ public enum PrefabPatchOrdering
 public enum PrefabPatchTargetKind
 {
     Stock,
-    PatchOwned
+    PatchOwned,
+    PatchComponent
 }
 
 [JsonConverter(typeof(StringEnumConverter))]
@@ -68,16 +69,17 @@ public enum PrefabPatchValueKind
     Vector3,
     Vector4,
     Quaternion,
-    Color
+    Color,
+    ArraySize,
+    ManagedReference,
+    Json
 }
 
 [JsonConverter(typeof(StringEnumConverter))]
-public enum PrefabPatchComponentKind
+public enum PrefabPatchObjectReferenceKind
 {
-    BoxCollider,
-    SphereCollider,
-    MeshFilter,
-    MeshRenderer
+    Addressable,
+    Target
 }
 
 /// <summary>
@@ -128,13 +130,16 @@ public sealed class PrefabPatchObjectTarget
     public string ObjectType;
     public string OwnerPatchId;
     public string ObjectId;
+    public string ComponentId;
     public PrefabPatchRuntimeLocator RuntimeLocator;
 
     [JsonIgnore]
     public string CanonicalKey =>
         Kind == PrefabPatchTargetKind.Stock
             ? $"stock:{SourceSerializedFileName}:{SourcePathId}:{ObjectType}"
-            : $"patch:{OwnerPatchId}:{ObjectId}";
+            : Kind == PrefabPatchTargetKind.PatchComponent
+                ? $"patch-component:{OwnerPatchId}:{ComponentId}"
+                : $"patch:{OwnerPatchId}:{ObjectId}";
 }
 
 /// <summary>
@@ -149,6 +154,7 @@ public sealed class PrefabPatchValue
     public long Integer;
     public double Float;
     public string String;
+    public string SerializedType;
     public double X;
     public double Y;
     public double Z;
@@ -168,35 +174,78 @@ public sealed class PrefabPatchValue
 }
 
 /// <summary>
-/// Addressable Unity object reference used by SetObjectReference or a component
-/// fragment. Source identity is retained for compatibility diagnostics.
+/// Addressable or target-local Unity object reference used by
+/// SetObjectReference or a component fragment. Source identity is retained for
+/// compatibility diagnostics.
 /// </summary>
 [Serializable]
 public sealed class PrefabPatchObjectReference
 {
+    public PrefabPatchObjectReferenceKind Kind;
     public string Address;
     public string ExpectedType;
     public string CatalogId;
     public string SourceBundleFileName;
     public string SourceSerializedFileName;
     public long SourcePathId;
+    public PrefabPatchObjectTarget Target;
+
+    public static PrefabPatchObjectReference FromAddress(
+        string address,
+        string expectedType = null
+    ) =>
+        new()
+        {
+            Kind = PrefabPatchObjectReferenceKind.Addressable,
+            Address = address,
+            ExpectedType = expectedType
+        };
+
+    public static PrefabPatchObjectReference FromTarget(
+        PrefabPatchObjectTarget target,
+        string expectedType = null
+    ) =>
+        new()
+        {
+            Kind = PrefabPatchObjectReferenceKind.Target,
+            Target = target,
+            ExpectedType = expectedType
+        };
 }
 
 /// <summary>
-/// Constrained component payload used for added patch-owned objects and
-/// AddComponent operations.
+/// One serialized field/property value captured from an arbitrary component.
+/// Visual, C#, and Lua authoring all emit this property-stream representation.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchSerializedValue
+{
+    public string PropertyPath;
+    public PrefabPatchValue Value;
+}
+
+/// <summary>
+/// One Unity object reference removed from a serialized component payload and
+/// restored after every patch-owned object and component has been created.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchSerializedReference
+{
+    public string PropertyPath;
+    public PrefabPatchObjectReference Reference;
+}
+
+/// <summary>
+/// Serialized payload used for added patch-owned objects and AddComponent
+/// operations.
 /// </summary>
 [Serializable]
 public sealed class PrefabPatchComponentFragment
 {
-    public PrefabPatchComponentKind Kind;
     public string ComponentId;
-    public bool Enabled = true;
-    public PrefabPatchValue Center;
-    public PrefabPatchValue Size;
-    public double Radius;
-    public bool IsTrigger;
-    public PrefabPatchObjectReference Mesh;
+    public string ComponentType;
+    public List<PrefabPatchSerializedValue> Values = new();
+    public List<PrefabPatchSerializedReference> References = new();
 }
 
 /// <summary>
@@ -208,10 +257,19 @@ public sealed class PrefabPatchObjectFragment
 {
     public string ObjectId;
     public string Name;
+    public string TransformType;
     public bool Active = true;
+    public int Layer;
+    public string Tag = "Untagged";
+    public bool IsStatic;
     public PrefabPatchValue LocalPosition;
     public PrefabPatchValue LocalRotation;
     public PrefabPatchValue LocalScale;
+    public PrefabPatchValue AnchorMin;
+    public PrefabPatchValue AnchorMax;
+    public PrefabPatchValue AnchoredPosition;
+    public PrefabPatchValue SizeDelta;
+    public PrefabPatchValue Pivot;
     public List<PrefabPatchComponentFragment> Components = new();
     public List<PrefabPatchObjectFragment> Children = new();
 }

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs
@@ -12,7 +12,18 @@ public static class PrefabPatchSchema
 {
     public const int Version = 1;
     public const int ComposerVersion = 1;
-    public const string AddressablesLabel = "patch-manager-prefab-patches";
+    public const string AddressablesLabelSuffix = "_prefab_patches";
+}
+
+/// <summary>
+/// One active mod's Addressables discovery boundary for declarative prefab
+/// patches. The mod descriptor supplies ownership; the manifest asset address
+/// is deliberately not part of patch identity.
+/// </summary>
+public sealed class PrefabPatchManifestSource
+{
+    public string OwnerModId;
+    public string AddressablesLabel;
 }
 
 [JsonConverter(typeof(StringEnumConverter))]

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs
@@ -10,8 +10,8 @@ namespace PatchManager.PrefabPatching;
 /// </summary>
 public static class PrefabPatchSchema
 {
-    public const int Version = 2;
-    public const int ComposerVersion = 2;
+    public const int Version = 1;
+    public const int ComposerVersion = 1;
     public const string AddressablesLabel = "patch-manager-prefab-patches";
 }
 
@@ -281,6 +281,7 @@ public sealed class PrefabPatchObjectFragment
 public sealed class PrefabPatchOperation
 {
     public string OperationId;
+    [JsonIgnore]
     public string PatchId;
     public PrefabPatchOperationKind Kind;
     public PrefabPatchObjectTarget Target;
@@ -329,9 +330,11 @@ public sealed class PrefabPatchManifest
 {
     public int SchemaVersion = PrefabPatchSchema.Version;
     public int ComposerVersion = PrefabPatchSchema.ComposerVersion;
+    public string PatchName;
+    [JsonIgnore]
     public string PatchId;
+    [JsonIgnore]
     public string ModId;
-    public string ModVersion;
     public PrefabPatchPrefabIdentity TargetPrefab;
     public PrefabPatchPass Pass = PrefabPatchPass.Default;
     public PrefabPatchOrdering Ordering = PrefabPatchOrdering.Default;

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs
@@ -94,6 +94,7 @@ public sealed class PrefabPatchPrefabIdentity
     public string SourceSerializedFileName;
     public long SourcePathId;
     public string AssetType;
+    public string StructuralDescription;
     public string StructuralFingerprint;
 
     [JsonIgnore]

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Versioned public schema for declarative prefab patches.
+/// </summary>
+public static class PrefabPatchSchema
+{
+    public const int Version = 1;
+    public const int ComposerVersion = 1;
+    public const string AddressablesLabel = "patch-manager-prefab-patches";
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchPass
+{
+    Early,
+    Default,
+    Late
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchOrdering
+{
+    First,
+    Default,
+    Last
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchTargetKind
+{
+    Stock,
+    PatchOwned
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchRuntimeTargetKind
+{
+    GameObject,
+    Component
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchOperationKind
+{
+    SetValue,
+    SetObjectReference,
+    SetActive,
+    AddObject,
+    SuppressObject,
+    AddComponent,
+    RemoveComponent
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchValueKind
+{
+    Boolean,
+    Integer,
+    Float,
+    String,
+    Vector2,
+    Vector3,
+    Vector4,
+    Quaternion,
+    Color
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchComponentKind
+{
+    BoxCollider,
+    SphereCollider,
+    MeshFilter,
+    MeshRenderer
+}
+
+/// <summary>
+/// Canonical identity and compatibility data for one stock Addressable prefab.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchPrefabIdentity
+{
+    public string Address;
+    public string CatalogId;
+    public string CatalogHash;
+    public string SourceBundleFileName;
+    public string SourceBundleHash;
+    public string SourceSerializedFileName;
+    public long SourcePathId;
+    public string AssetType;
+    public string StructuralFingerprint;
+
+    [JsonIgnore]
+    public string CanonicalKey =>
+        $"{CatalogId}|{SourceSerializedFileName}|{SourcePathId}|{AssetType}";
+}
+
+/// <summary>
+/// Deterministic runtime traversal hint. It is validated against the manifest's
+/// source identity and structural fingerprint; it is never the canonical ID.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchRuntimeLocator
+{
+    public int[] SiblingIndices = Array.Empty<int>();
+    public PrefabPatchRuntimeTargetKind TargetKind;
+    public string ComponentType;
+    public int ComponentOrdinal;
+    public string DisplayPath;
+}
+
+/// <summary>
+/// An inherited source object or an object introduced by a named patch.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchObjectTarget
+{
+    public PrefabPatchTargetKind Kind;
+    public string SourceSerializedFileName;
+    public long SourcePathId;
+    public string ObjectType;
+    public string OwnerPatchId;
+    public string ObjectId;
+    public PrefabPatchRuntimeLocator RuntimeLocator;
+
+    [JsonIgnore]
+    public string CanonicalKey =>
+        Kind == PrefabPatchTargetKind.Stock
+            ? $"stock:{SourceSerializedFileName}:{SourcePathId}:{ObjectType}"
+            : $"patch:{OwnerPatchId}:{ObjectId}";
+}
+
+/// <summary>
+/// JSON-safe typed value. Numeric vectors use X/Y/Z/W in their normal Unity
+/// component order.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchValue
+{
+    public PrefabPatchValueKind Kind;
+    public bool Boolean;
+    public long Integer;
+    public double Float;
+    public string String;
+    public double X;
+    public double Y;
+    public double Z;
+    public double W;
+
+    public static PrefabPatchValue FromBoolean(bool value) =>
+        new() { Kind = PrefabPatchValueKind.Boolean, Boolean = value };
+
+    public static PrefabPatchValue FromInteger(long value) =>
+        new() { Kind = PrefabPatchValueKind.Integer, Integer = value };
+
+    public static PrefabPatchValue FromFloat(double value) =>
+        new() { Kind = PrefabPatchValueKind.Float, Float = value };
+
+    public static PrefabPatchValue FromString(string value) =>
+        new() { Kind = PrefabPatchValueKind.String, String = value };
+}
+
+/// <summary>
+/// Addressable Unity object reference used by SetObjectReference or a component
+/// fragment. Source identity is retained for compatibility diagnostics.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchObjectReference
+{
+    public string Address;
+    public string ExpectedType;
+    public string CatalogId;
+    public string SourceBundleFileName;
+    public string SourceSerializedFileName;
+    public long SourcePathId;
+}
+
+/// <summary>
+/// Constrained component payload used for added patch-owned objects and
+/// AddComponent operations.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchComponentFragment
+{
+    public PrefabPatchComponentKind Kind;
+    public string ComponentId;
+    public bool Enabled = true;
+    public PrefabPatchValue Center;
+    public PrefabPatchValue Size;
+    public double Radius;
+    public bool IsTrigger;
+    public PrefabPatchObjectReference Mesh;
+}
+
+/// <summary>
+/// An inline, patch-owned hierarchy fragment. Every object has an explicit ID,
+/// allowing later required patches to target it without hierarchy-name lookup.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchObjectFragment
+{
+    public string ObjectId;
+    public string Name;
+    public bool Active = true;
+    public PrefabPatchValue LocalPosition;
+    public PrefabPatchValue LocalRotation;
+    public PrefabPatchValue LocalScale;
+    public List<PrefabPatchComponentFragment> Components = new();
+    public List<PrefabPatchObjectFragment> Children = new();
+}
+
+/// <summary>
+/// One normalized declarative operation.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchOperation
+{
+    public string OperationId;
+    public string PatchId;
+    public PrefabPatchOperationKind Kind;
+    public PrefabPatchObjectTarget Target;
+    public string PropertyPath;
+    public PrefabPatchValue Value;
+    public PrefabPatchObjectReference ObjectReference;
+    public PrefabPatchObjectFragment AddedObject;
+    public PrefabPatchComponentFragment AddedComponent;
+    public string ExpectedOriginalFingerprint;
+    public string AuthoringAssetPath;
+    public string AuthoringPropertyPath;
+
+    [JsonIgnore]
+    public string ConflictKey
+    {
+        get
+        {
+            var target = Target?.CanonicalKey ?? "<missing-target>";
+            return Kind switch
+            {
+                PrefabPatchOperationKind.SetValue =>
+                    $"{target}:value:{PropertyPath}",
+                PrefabPatchOperationKind.SetObjectReference =>
+                    $"{target}:object:{PropertyPath}",
+                PrefabPatchOperationKind.SetActive =>
+                    $"{target}:active",
+                PrefabPatchOperationKind.SuppressObject =>
+                    $"{target}:suppressed",
+                PrefabPatchOperationKind.RemoveComponent =>
+                    $"{target}:removed",
+                PrefabPatchOperationKind.AddObject =>
+                    $"patch:{PatchId}:{AddedObject?.ObjectId}:introduced",
+                PrefabPatchOperationKind.AddComponent =>
+                    $"{target}:component:{AddedComponent?.ComponentId}",
+                _ => $"{target}:{Kind}:{OperationId}"
+            };
+        }
+    }
+}
+
+/// <summary>
+/// One independently distributable prefab patch manifest.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchManifest
+{
+    public int SchemaVersion = PrefabPatchSchema.Version;
+    public int ComposerVersion = PrefabPatchSchema.ComposerVersion;
+    public string PatchId;
+    public string ModId;
+    public string ModVersion;
+    public PrefabPatchPrefabIdentity TargetPrefab;
+    public PrefabPatchPass Pass = PrefabPatchPass.Default;
+    public PrefabPatchOrdering Ordering = PrefabPatchOrdering.Default;
+    public string[] NeedsMods = Array.Empty<string>();
+    public string[] ConflictsMods = Array.Empty<string>();
+    public string[] NeedsPatches = Array.Empty<string>();
+    public string[] ConflictsPatches = Array.Empty<string>();
+    public string[] BeforePatches = Array.Empty<string>();
+    public string[] AfterPatches = Array.Empty<string>();
+    public string[] BeforeMods = Array.Empty<string>();
+    public string[] AfterMods = Array.Empty<string>();
+    public string[] ConfigurationInputs = Array.Empty<string>();
+    public string[] DeclaredCapabilities = Array.Empty<string>();
+    public List<PrefabPatchOperation> Operations = new();
+    public string ManifestHash;
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum PrefabPatchDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+/// <summary>
+/// Machine-readable ordering, compatibility, conflict, cache, or composition
+/// diagnostic.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchDiagnostic
+{
+    public PrefabPatchDiagnosticSeverity Severity;
+    public string Code;
+    public string TargetAddress;
+    public string PatchId;
+    public string OperationId;
+    public string Message;
+}
+
+/// <summary>
+/// Cacheable result of discovery, dependency resolution, ordering, conflict
+/// analysis, and normalized operation validation for one stock prefab.
+/// </summary>
+[Serializable]
+public sealed class PrefabPatchResolvedPlan
+{
+    public int SchemaVersion = PrefabPatchSchema.Version;
+    public int ComposerVersion = PrefabPatchSchema.ComposerVersion;
+    public string CacheKey;
+    public string SourceFingerprint;
+    public string InputHash;
+    public PrefabPatchPrefabIdentity TargetPrefab;
+    public string[] OrderedPatchIds = Array.Empty<string>();
+    public List<PrefabPatchOperation> Operations = new();
+    public List<PrefabPatchDiagnostic> Diagnostics = new();
+    public bool IsValid;
+    public long ResolvedUtcTicks;
+}

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs
@@ -100,18 +100,52 @@ public sealed class PrefabPatchPrefabIdentity
     public string StructuralFingerprint;
 
     [JsonIgnore]
+    public bool HasCanonicalMetadata =>
+        !string.IsNullOrWhiteSpace(CatalogId)
+        || !string.IsNullOrWhiteSpace(CatalogHash)
+        || !string.IsNullOrWhiteSpace(SourceBundleFileName)
+        || !string.IsNullOrWhiteSpace(SourceBundleHash)
+        || !string.IsNullOrWhiteSpace(SourceSerializedFileName)
+        || SourcePathId != 0
+        || !string.IsNullOrWhiteSpace(StructuralDescription)
+        || !string.IsNullOrWhiteSpace(StructuralFingerprint);
+
+    [JsonIgnore]
+    public bool IsCanonical =>
+        !string.IsNullOrWhiteSpace(SourceSerializedFileName)
+        && SourcePathId != 0
+        && !string.IsNullOrWhiteSpace(StructuralFingerprint);
+
+    [JsonIgnore]
     public string CanonicalKey =>
-        $"{CatalogId}|{SourceSerializedFileName}|{SourcePathId}|{AssetType}";
+        IsCanonical
+            ? $"{CatalogId}|{SourceSerializedFileName}|{SourcePathId}|{AssetType}"
+            : $"address:{Address}";
+
+    public static PrefabPatchPrefabIdentity FromAddress(string address)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+            throw new ArgumentException(
+                "Addressables key is required.",
+                nameof(address)
+            );
+        return new PrefabPatchPrefabIdentity
+        {
+            Address = address.Trim(),
+            AssetType = typeof(UnityEngine.GameObject).AssemblyQualifiedName
+        };
+    }
 }
 
 /// <summary>
-/// Deterministic runtime traversal hint. It is validated against the manifest's
-/// source identity and structural fingerprint; it is never the canonical ID.
+/// Runtime traversal data. Visual compilation uses sibling indices backed by
+/// canonical source identity; key-first C#/Lua authoring uses a hierarchy path.
 /// </summary>
 [Serializable]
 public sealed class PrefabPatchRuntimeLocator
 {
     public int[] SiblingIndices = Array.Empty<int>();
+    public string HierarchyPath;
     public PrefabPatchRuntimeTargetKind TargetKind;
     public string ComponentType;
     public int ComponentOrdinal;
@@ -134,12 +168,29 @@ public sealed class PrefabPatchObjectTarget
     public PrefabPatchRuntimeLocator RuntimeLocator;
 
     [JsonIgnore]
-    public string CanonicalKey =>
-        Kind == PrefabPatchTargetKind.Stock
-            ? $"stock:{SourceSerializedFileName}:{SourcePathId}:{ObjectType}"
-            : Kind == PrefabPatchTargetKind.PatchComponent
-                ? $"patch-component:{OwnerPatchId}:{ComponentId}"
-                : $"patch:{OwnerPatchId}:{ObjectId}";
+    public string CanonicalKey
+    {
+        get
+        {
+            if (Kind == PrefabPatchTargetKind.PatchComponent)
+                return $"patch-component:{OwnerPatchId}:{ComponentId}";
+            if (Kind == PrefabPatchTargetKind.PatchOwned)
+                return $"patch:{OwnerPatchId}:{ObjectId}";
+
+            var path = !string.IsNullOrWhiteSpace(
+                RuntimeLocator?.HierarchyPath
+            )
+                ? RuntimeLocator.HierarchyPath
+                : RuntimeLocator?.DisplayPath;
+            if (!string.IsNullOrWhiteSpace(path))
+                return $"path:{path}:{RuntimeLocator.TargetKind}:"
+                    + $"{RuntimeLocator.ComponentType}:"
+                    + $"{RuntimeLocator.ComponentOrdinal}";
+
+            return $"stock:{SourceSerializedFileName}:"
+                + $"{SourcePathId}:{ObjectType}";
+        }
+    }
 }
 
 /// <summary>

--- a/Runtime/PrefabPatching/PrefabPatchModel.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchModel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7e84cd69b3f4824cb0855b8a36088cc

--- a/Runtime/PrefabPatching/PrefabPatchObjectId.cs
+++ b/Runtime/PrefabPatching/PrefabPatchObjectId.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Explicit stable ID for a GameObject introduced by a visual prefab patch.
+/// Later patches address it as owning patch ID plus this patch-local ID.
+/// </summary>
+[DisallowMultipleComponent]
+public sealed class PrefabPatchObjectId : MonoBehaviour
+{
+    [SerializeField] private string _id;
+
+    public string Id
+    {
+        get => _id;
+        set => _id = value;
+    }
+}

--- a/Runtime/PrefabPatching/PrefabPatchObjectId.cs
+++ b/Runtime/PrefabPatching/PrefabPatchObjectId.cs
@@ -1,19 +1,20 @@
 using UnityEngine;
 
-namespace PatchManager.PrefabPatching;
-
-/// <summary>
-/// Explicit stable ID for a GameObject introduced by a visual prefab patch.
-/// Later patches address it as owning patch ID plus this patch-local ID.
-/// </summary>
-[DisallowMultipleComponent]
-public sealed class PrefabPatchObjectId : MonoBehaviour
+namespace PatchManager.PrefabPatching
 {
-    [SerializeField] private string _id;
-
-    public string Id
+    /// <summary>
+    /// Explicit stable ID for a GameObject introduced by a visual prefab patch.
+    /// Later patches address it as owning patch ID plus this patch-local ID.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class PrefabPatchObjectId : MonoBehaviour
     {
-        get => _id;
-        set => _id = value;
+        [SerializeField] private string _id;
+
+        public string Id
+        {
+            get => _id;
+            set => _id = value;
+        }
     }
 }

--- a/Runtime/PrefabPatching/PrefabPatchObjectId.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchObjectId.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 93da1f45b46a3f243ae12acca9ebff3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/PrefabPatching/PrefabPatchObjectId.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchObjectId.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93da1f45b46a3f243ae12acca9ebff3a

--- a/Runtime/PrefabPatching/PrefabPatchOwnership.cs
+++ b/Runtime/PrefabPatching/PrefabPatchOwnership.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Applies the containing mod's runtime identity to an ownership-free prefab
+/// patch manifest. Serialized manifests deliberately do not duplicate swinfo
+/// metadata.
+/// </summary>
+public static class PrefabPatchOwnership
+{
+    public static PrefabPatchManifest Bind(
+        PrefabPatchManifest manifest,
+        string modId
+    )
+    {
+        if (manifest == null)
+            throw new ArgumentNullException(nameof(manifest));
+        if (string.IsNullOrWhiteSpace(modId))
+            throw new ArgumentException(
+                "The containing mod ID is required.",
+                nameof(modId)
+            );
+        if (string.IsNullOrWhiteSpace(manifest.PatchName))
+            throw new InvalidOperationException(
+                "Prefab patch manifests must define a local patchName."
+            );
+        if (manifest.PatchName.IndexOf(':') >= 0)
+            throw new InvalidOperationException(
+                $"Prefab patch name '{manifest.PatchName}' must be local to "
+                    + "its containing mod and cannot contain ':'."
+            );
+
+        modId = modId.Trim();
+        if (!string.IsNullOrWhiteSpace(manifest.ModId))
+        {
+            if (!string.Equals(manifest.ModId, modId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Prefab patch '{manifest.PatchName}' is already bound to "
+                        + $"'{manifest.ModId}', not '{modId}'."
+                );
+            }
+        }
+
+        var authoredHash = PrefabPatchJson.CalculateManifestHash(manifest);
+        if (
+            !string.IsNullOrWhiteSpace(manifest.ManifestHash)
+            && !string.Equals(
+                authoredHash,
+                manifest.ManifestHash,
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            throw new InvalidOperationException(
+                $"Prefab patch '{manifest.PatchName}' manifest hash does not "
+                    + "match its authored content."
+            );
+        }
+
+        manifest.ModId = modId;
+        manifest.PatchId = Qualify(modId, manifest.PatchName);
+        manifest.NeedsPatches = QualifyAll(modId, manifest.NeedsPatches);
+        manifest.ConflictsPatches = QualifyAll(
+            modId,
+            manifest.ConflictsPatches
+        );
+        manifest.BeforePatches = QualifyAll(modId, manifest.BeforePatches);
+        manifest.AfterPatches = QualifyAll(modId, manifest.AfterPatches);
+
+        foreach (var operation in manifest.Operations ?? new())
+        {
+            if (operation == null)
+                continue;
+            operation.PatchId = manifest.PatchId;
+            BindTarget(operation.Target, modId);
+            BindReference(operation.ObjectReference, modId);
+            BindFragment(operation.AddedObject, modId);
+            BindComponent(operation.AddedComponent, modId);
+        }
+
+        manifest.ManifestHash = PrefabPatchJson.CalculateManifestHash(manifest);
+        return manifest;
+    }
+
+    public static string Qualify(string modId, string patchNameOrId)
+    {
+        if (string.IsNullOrWhiteSpace(patchNameOrId))
+            return patchNameOrId;
+        var value = patchNameOrId.Trim();
+        return value.IndexOf(':') >= 0 ? value : modId + ":" + value;
+    }
+
+    private static string[] QualifyAll(
+        string modId,
+        IEnumerable<string> values
+    ) =>
+        (values ?? Array.Empty<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => Qualify(modId, value))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .ToArray();
+
+    private static void BindFragment(
+        PrefabPatchObjectFragment fragment,
+        string modId
+    )
+    {
+        if (fragment == null)
+            return;
+        foreach (var component in fragment.Components ?? new())
+            BindComponent(component, modId);
+        foreach (var child in fragment.Children ?? new())
+            BindFragment(child, modId);
+    }
+
+    private static void BindComponent(
+        PrefabPatchComponentFragment component,
+        string modId
+    )
+    {
+        if (component == null)
+            return;
+        foreach (var reference in component.References ?? new())
+            BindReference(reference?.Reference, modId);
+    }
+
+    private static void BindReference(
+        PrefabPatchObjectReference reference,
+        string modId
+    )
+    {
+        if (reference?.Kind == PrefabPatchObjectReferenceKind.Target)
+            BindTarget(reference.Target, modId);
+    }
+
+    private static void BindTarget(
+        PrefabPatchObjectTarget target,
+        string modId
+    )
+    {
+        if (
+            target == null
+            || target.Kind == PrefabPatchTargetKind.Stock
+            || string.IsNullOrWhiteSpace(target.OwnerPatchId)
+        )
+        {
+            return;
+        }
+        target.OwnerPatchId = Qualify(modId, target.OwnerPatchId);
+    }
+}

--- a/Runtime/PrefabPatching/PrefabPatchOwnership.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchOwnership.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3047e1f9c26b604d867329b03c2f316

--- a/Runtime/PrefabPatching/PrefabPatchPlanCache.cs
+++ b/Runtime/PrefabPatching/PrefabPatchPlanCache.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Atomic, recoverable, per-prefab resolved-plan cache. A cache hit avoids
+/// dependency ordering, target validation, and conflict analysis.
+/// </summary>
+public sealed class PrefabPatchPlanCache
+{
+    public sealed class Result
+    {
+        public PrefabPatchResolvedPlan Plan;
+        public bool CacheHit;
+        public bool RecoveredBackup;
+        public long ElapsedMilliseconds;
+        public string Path;
+    }
+
+    private readonly string _directory;
+
+    public PrefabPatchPlanCache(string directory)
+    {
+        _directory = Path.GetFullPath(directory);
+    }
+
+    public Result LoadOrResolve(
+        IEnumerable<PrefabPatchManifest> source,
+        ISet<string> activeModIds,
+        string unityVersion,
+        string targetPlatform
+    )
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var manifests = source
+            .Where(value => value != null)
+            .OrderBy(value => value.PatchId, StringComparer.Ordinal)
+            .ToList();
+        if (manifests.Count == 0)
+        {
+            var empty = PrefabPatchResolver.Resolve(
+                manifests,
+                activeModIds,
+                unityVersion,
+                targetPlatform
+            );
+            stopwatch.Stop();
+            return new Result
+            {
+                Plan = empty,
+                ElapsedMilliseconds = stopwatch.ElapsedMilliseconds
+            };
+        }
+
+        Directory.CreateDirectory(_directory);
+        var sourceFingerprint = CalculateSourceFingerprint(
+            manifests,
+            activeModIds,
+            unityVersion,
+            targetPlatform
+        );
+        var path = GetPath(manifests[0].TargetPrefab);
+        if (TryRead(path, sourceFingerprint, out var cached))
+        {
+            stopwatch.Stop();
+            return new Result
+            {
+                Plan = cached,
+                CacheHit = true,
+                ElapsedMilliseconds = stopwatch.ElapsedMilliseconds,
+                Path = path
+            };
+        }
+
+        var backupPath = path + ".bak";
+        if (TryRead(backupPath, sourceFingerprint, out cached))
+        {
+            AtomicWrite(path, PrefabPatchJson.Serialize(cached));
+            stopwatch.Stop();
+            return new Result
+            {
+                Plan = cached,
+                CacheHit = true,
+                RecoveredBackup = true,
+                ElapsedMilliseconds = stopwatch.ElapsedMilliseconds,
+                Path = path
+            };
+        }
+
+        var plan = PrefabPatchResolver.Resolve(
+            manifests,
+            activeModIds,
+            unityVersion,
+            targetPlatform
+        );
+        plan.SourceFingerprint = sourceFingerprint;
+        if (plan.IsValid)
+            AtomicWrite(path, PrefabPatchJson.Serialize(plan));
+        stopwatch.Stop();
+        return new Result
+        {
+            Plan = plan,
+            CacheHit = false,
+            ElapsedMilliseconds = stopwatch.ElapsedMilliseconds,
+            Path = path
+        };
+    }
+
+    public string GetPath(PrefabPatchPrefabIdentity target)
+    {
+        var identity = target?.CanonicalKey ?? target?.Address ?? "invalid";
+        return Path.Combine(
+            _directory,
+            PrefabPatchJson.Sha256(identity) + ".plan.json"
+        );
+    }
+
+    public static string CalculateSourceFingerprint(
+        IEnumerable<PrefabPatchManifest> manifests,
+        ISet<string> activeModIds,
+        string unityVersion,
+        string targetPlatform
+    )
+    {
+        var ordered = manifests
+            .Where(value => value != null)
+            .OrderBy(value => value.PatchId, StringComparer.Ordinal)
+            .ToList();
+        foreach (var manifest in ordered)
+        {
+            foreach (var operation in manifest.Operations)
+                operation.PatchId = manifest.PatchId;
+            manifest.ManifestHash = PrefabPatchJson.CalculateManifestHash(manifest);
+        }
+        var value = new
+        {
+            UnityVersion = unityVersion,
+            TargetPlatform = targetPlatform,
+            SchemaVersion = PrefabPatchSchema.Version,
+            ComposerVersion = PrefabPatchSchema.ComposerVersion,
+            Target = ordered.FirstOrDefault()?.TargetPrefab,
+            ActiveMods = activeModIds.OrderBy(
+                id => id,
+                StringComparer.Ordinal
+            ),
+            Manifests = ordered.Select(
+                manifest => new
+                {
+                    manifest.PatchId,
+                    manifest.ManifestHash,
+                    manifest.ConfigurationInputs
+                }
+            )
+        };
+        return PrefabPatchJson.Sha256(PrefabPatchJson.Serialize(value));
+    }
+
+    private static bool TryRead(
+        string path,
+        string sourceFingerprint,
+        out PrefabPatchResolvedPlan plan
+    )
+    {
+        plan = null;
+        if (!File.Exists(path))
+            return false;
+        try
+        {
+            plan = PrefabPatchJson.Deserialize<PrefabPatchResolvedPlan>(
+                File.ReadAllText(path)
+            );
+            return plan != null
+                && plan.SchemaVersion == PrefabPatchSchema.Version
+                && plan.ComposerVersion == PrefabPatchSchema.ComposerVersion
+                && plan.IsValid
+                && string.Equals(
+                    plan.SourceFingerprint,
+                    sourceFingerprint,
+                    StringComparison.Ordinal
+                );
+        }
+        catch
+        {
+            plan = null;
+            return false;
+        }
+    }
+
+    private static void AtomicWrite(string path, string contents)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (string.IsNullOrWhiteSpace(directory))
+            throw new InvalidOperationException(
+                $"Cache path '{path}' has no directory."
+            );
+        Directory.CreateDirectory(directory);
+        var tempPath = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        var backupPath = path + ".bak";
+        try
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(contents);
+            using (
+                var stream = new FileStream(
+                    tempPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    4096,
+                    FileOptions.WriteThrough
+                )
+            )
+            {
+                stream.Write(bytes, 0, bytes.Length);
+                stream.Flush(true);
+            }
+
+            if (File.Exists(path))
+            {
+                try
+                {
+                    File.Replace(tempPath, path, backupPath, true);
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    File.Copy(path, backupPath, true);
+                    File.Delete(path);
+                    File.Move(tempPath, path);
+                }
+            }
+            else
+            {
+                File.Move(tempPath, path);
+            }
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
+}

--- a/Runtime/PrefabPatching/PrefabPatchPlanCache.cs
+++ b/Runtime/PrefabPatching/PrefabPatchPlanCache.cs
@@ -112,7 +112,7 @@ public sealed class PrefabPatchPlanCache
 
     public string GetPath(PrefabPatchPrefabIdentity target)
     {
-        var identity = target?.CanonicalKey ?? target?.Address ?? "invalid";
+        var identity = target?.Address ?? target?.CanonicalKey ?? "invalid";
         return Path.Combine(
             _directory,
             PrefabPatchJson.Sha256(identity) + ".plan.json"

--- a/Runtime/PrefabPatching/PrefabPatchPlanCache.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchPlanCache.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91789b61dfb65b240a5be7121003c473

--- a/Runtime/PrefabPatching/PrefabPatchResolver.cs
+++ b/Runtime/PrefabPatching/PrefabPatchResolver.cs
@@ -41,7 +41,12 @@ public static class PrefabPatchResolver
         plan.TargetPrefab = manifests
             .Select(manifest => manifest.TargetPrefab)
             .Where(target => target != null)
-            .OrderByDescending(target => target.IsCanonical)
+            .OrderByDescending(
+                target =>
+                    !string.IsNullOrWhiteSpace(
+                        target.StructuralFingerprint
+                    )
+            )
             .FirstOrDefault();
         var address = plan.TargetPrefab?.Address;
         var fatal = false;
@@ -64,9 +69,17 @@ public static class PrefabPatchResolver
                     "PM-PREFAB-MIXED-TARGET",
                     manifest.PatchId,
                     null,
-                    $"Patch '{manifest.PatchId}' targets "
-                        + $"'{manifest.TargetPrefab.Address}', not "
-                        + $"'{plan.TargetPrefab.Address}'."
+                    string.Equals(
+                        manifest.TargetPrefab.Address,
+                        plan.TargetPrefab.Address,
+                        StringComparison.Ordinal
+                    )
+                        ? $"Patch '{manifest.PatchId}' was compiled against "
+                            + "a different structural version of "
+                            + $"'{plan.TargetPrefab.Address}'."
+                        : $"Patch '{manifest.PatchId}' targets "
+                            + $"'{manifest.TargetPrefab.Address}', not "
+                            + $"'{plan.TargetPrefab.Address}'."
                 );
                 fatal = true;
                 continue;
@@ -189,25 +202,6 @@ public static class PrefabPatchResolver
             return false;
         }
 
-        if (
-            manifest.TargetPrefab.HasCanonicalMetadata
-            && !manifest.TargetPrefab.IsCanonical
-        )
-        {
-            Add(
-                plan,
-                PrefabPatchDiagnosticSeverity.Error,
-                "PM-PREFAB-TARGET-IDENTITY",
-                manifest.PatchId,
-                null,
-                $"Patch '{manifest.PatchId}' contains partial compiler "
-                    + "identity metadata. Imperative patches should specify "
-                    + "only the Addressables key; visual manifests must contain "
-                    + "a complete CAB/path identity and structural fingerprint."
-            );
-            return false;
-        }
-
         var calculatedHash = PrefabPatchJson.CalculateManifestHash(manifest);
         if (
             !string.IsNullOrWhiteSpace(manifest.ManifestHash)
@@ -249,11 +243,11 @@ public static class PrefabPatchResolver
             )
         )
             return false;
-        return !left.IsCanonical
-            || !right.IsCanonical
+        return string.IsNullOrWhiteSpace(left.StructuralFingerprint)
+            || string.IsNullOrWhiteSpace(right.StructuralFingerprint)
             || string.Equals(
-                left.CanonicalKey,
-                right.CanonicalKey,
+                left.StructuralFingerprint,
+                right.StructuralFingerprint,
                 StringComparison.Ordinal
             );
     }

--- a/Runtime/PrefabPatching/PrefabPatchResolver.cs
+++ b/Runtime/PrefabPatching/PrefabPatchResolver.cs
@@ -495,6 +495,9 @@ public static class PrefabPatchResolver
             .Select((manifest, index) => (manifest.PatchId, index))
             .ToDictionary(pair => pair.PatchId, pair => pair.index);
         var introduced = new Dictionary<string, string>(StringComparer.Ordinal);
+        var introducedComponents = new Dictionary<string, string>(
+            StringComparer.Ordinal
+        );
         var writes = new Dictionary<string, PrefabPatchOperation>(
             StringComparer.Ordinal
         );
@@ -508,7 +511,6 @@ public static class PrefabPatchResolver
             foreach (
                 var operation in manifest.Operations
                     .Where(value => value != null)
-                    .OrderBy(value => value.OperationId, StringComparer.Ordinal)
             )
             {
                 operation.PatchId = manifest.PatchId;
@@ -546,11 +548,19 @@ public static class PrefabPatchResolver
 
                 if (
                     operation.Target?.Kind
-                    == PrefabPatchTargetKind.PatchOwned
+                        == PrefabPatchTargetKind.PatchOwned
+                    || operation.Target?.Kind
+                        == PrefabPatchTargetKind.PatchComponent
                 )
                 {
                     var owner = operation.Target.OwnerPatchId;
-                    var objectKey = $"{owner}:{operation.Target.ObjectId}";
+                    var isComponent =
+                        operation.Target.Kind
+                        == PrefabPatchTargetKind.PatchComponent;
+                    var ownedId = isComponent
+                        ? operation.Target.ComponentId
+                        : operation.Target.ObjectId;
+                    var objectKey = $"{owner}:{ownedId}";
                     if (
                         !string.Equals(
                             owner,
@@ -575,8 +585,24 @@ public static class PrefabPatchResolver
                     }
 
                     if (
-                        !introduced.ContainsKey(objectKey)
-                        || patchOrder[owner] >= patchOrder[manifest.PatchId]
+                        !(isComponent
+                            ? introducedComponents.ContainsKey(objectKey)
+                            : introduced.ContainsKey(objectKey))
+                        || (
+                            !string.Equals(
+                                owner,
+                                manifest.PatchId,
+                                StringComparison.Ordinal
+                            )
+                            && (
+                                !patchOrder.TryGetValue(
+                                    owner,
+                                    out var ownerOrder
+                                )
+                                || ownerOrder
+                                    >= patchOrder[manifest.PatchId]
+                            )
+                        )
                     )
                     {
                         Add(
@@ -585,7 +611,9 @@ public static class PrefabPatchResolver
                             "PM-PREFAB-PATCH-OWNED-TARGET",
                             manifest.PatchId,
                             operation.OperationId,
-                            $"Patch-owned target '{objectKey}' is not introduced "
+                            $"Patch-owned "
+                                + (isComponent ? "component" : "object")
+                                + $" target '{objectKey}' is not introduced "
                                 + "by an earlier required operation."
                         );
                         fatal = true;
@@ -595,33 +623,60 @@ public static class PrefabPatchResolver
 
                 if (operation.Kind == PrefabPatchOperationKind.AddObject)
                 {
-                    var objectId = operation.AddedObject?.ObjectId;
-                    var objectKey = $"{manifest.PatchId}:{objectId}";
-                    if (string.IsNullOrWhiteSpace(objectId))
+                    if (
+                        !RegisterFragment(
+                            operation.AddedObject,
+                            manifest.PatchId,
+                            operation.OperationId,
+                            introduced,
+                            introducedComponents,
+                            plan
+                        )
+                    )
+                        fatal = true;
+                }
+                else if (
+                    operation.Kind == PrefabPatchOperationKind.AddComponent
+                )
+                {
+                    var componentId = operation.AddedComponent?.ComponentId;
+                    var componentKey =
+                        $"{manifest.PatchId}:{componentId}";
+                    if (
+                        string.IsNullOrWhiteSpace(componentId)
+                        || string.IsNullOrWhiteSpace(
+                            operation.AddedComponent?.ComponentType
+                        )
+                    )
                     {
                         Add(
                             plan,
                             PrefabPatchDiagnosticSeverity.Error,
-                            "PM-PREFAB-ADDED-OBJECT-ID",
+                            "PM-PREFAB-ADDED-COMPONENT-ID",
                             manifest.PatchId,
                             operation.OperationId,
-                            $"Added object operation '{operation.OperationId}' "
-                                + "has no patch-local object ID."
+                            $"Added component operation "
+                                + $"'{operation.OperationId}' needs a stable "
+                                + "component ID and assembly-qualified type."
                         );
                         fatal = true;
                         continue;
                     }
-
-                    if (!introduced.TryAdd(objectKey, operation.OperationId))
+                    if (
+                        !introducedComponents.TryAdd(
+                            componentKey,
+                            operation.OperationId
+                        )
+                    )
                     {
                         Add(
                             plan,
                             PrefabPatchDiagnosticSeverity.Error,
-                            "PM-PREFAB-DUPLICATE-OBJECT-ID",
+                            "PM-PREFAB-DUPLICATE-COMPONENT-ID",
                             manifest.PatchId,
                             operation.OperationId,
-                            $"Patch-owned object '{objectKey}' is introduced "
-                                + "more than once."
+                            $"Patch-owned component '{componentKey}' is "
+                                + "introduced more than once."
                         );
                         fatal = true;
                         continue;
@@ -710,6 +765,106 @@ public static class PrefabPatchResolver
             )
         };
         return PrefabPatchJson.Sha256(PrefabPatchJson.Serialize(value));
+    }
+
+    private static bool RegisterFragment(
+        PrefabPatchObjectFragment fragment,
+        string patchId,
+        string operationId,
+        IDictionary<string, string> objects,
+        IDictionary<string, string> components,
+        PrefabPatchResolvedPlan plan
+    )
+    {
+        if (fragment == null || string.IsNullOrWhiteSpace(fragment.ObjectId))
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-ADDED-OBJECT-ID",
+                patchId,
+                operationId,
+                $"Added object operation '{operationId}' contains an object "
+                    + "without a stable patch-local ID."
+            );
+            return false;
+        }
+
+        var valid = true;
+        var objectKey = $"{patchId}:{fragment.ObjectId}";
+        if (!objects.TryAdd(objectKey, operationId))
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-DUPLICATE-OBJECT-ID",
+                patchId,
+                operationId,
+                $"Patch-owned object '{objectKey}' is introduced more than "
+                    + "once."
+            );
+            valid = false;
+        }
+
+        foreach (
+            var component in fragment.Components
+                ?? new List<PrefabPatchComponentFragment>()
+        )
+        {
+            var componentId = component?.ComponentId;
+            var componentKey = $"{patchId}:{componentId}";
+            if (
+                component == null
+                || string.IsNullOrWhiteSpace(componentId)
+                || string.IsNullOrWhiteSpace(component.ComponentType)
+            )
+            {
+                Add(
+                    plan,
+                    PrefabPatchDiagnosticSeverity.Error,
+                    "PM-PREFAB-ADDED-COMPONENT-ID",
+                    patchId,
+                    operationId,
+                    $"Patch-owned object '{objectKey}' contains a component "
+                        + "without a stable ID or assembly-qualified type."
+                );
+                valid = false;
+                continue;
+            }
+            if (!components.TryAdd(componentKey, operationId))
+            {
+                Add(
+                    plan,
+                    PrefabPatchDiagnosticSeverity.Error,
+                    "PM-PREFAB-DUPLICATE-COMPONENT-ID",
+                    patchId,
+                    operationId,
+                    $"Patch-owned component '{componentKey}' is introduced "
+                        + "more than once."
+                );
+                valid = false;
+            }
+        }
+
+        foreach (
+            var child in fragment.Children
+                ?? new List<PrefabPatchObjectFragment>()
+        )
+        {
+            if (
+                !RegisterFragment(
+                    child,
+                    patchId,
+                    operationId,
+                    objects,
+                    components,
+                    plan
+                )
+            )
+                valid = false;
+        }
+
+        return valid;
     }
 
     private static void AddSameBucketEdges(

--- a/Runtime/PrefabPatching/PrefabPatchResolver.cs
+++ b/Runtime/PrefabPatching/PrefabPatchResolver.cs
@@ -38,7 +38,11 @@ public static class PrefabPatchResolver
             return plan;
         }
 
-        plan.TargetPrefab = manifests[0].TargetPrefab;
+        plan.TargetPrefab = manifests
+            .Select(manifest => manifest.TargetPrefab)
+            .Where(target => target != null)
+            .OrderByDescending(target => target.IsCanonical)
+            .FirstOrDefault();
         var address = plan.TargetPrefab?.Address;
         var fatal = false;
         var byId = new Dictionary<string, PrefabPatchManifest>(
@@ -52,13 +56,7 @@ public static class PrefabPatchResolver
                 continue;
             }
 
-            if (
-                !string.Equals(
-                    manifest.TargetPrefab.CanonicalKey,
-                    plan.TargetPrefab.CanonicalKey,
-                    StringComparison.Ordinal
-                )
-            )
+            if (!TargetsMatch(manifest.TargetPrefab, plan.TargetPrefab))
             {
                 Add(
                     plan,
@@ -67,8 +65,8 @@ public static class PrefabPatchResolver
                     manifest.PatchId,
                     null,
                     $"Patch '{manifest.PatchId}' targets "
-                        + $"'{manifest.TargetPrefab.CanonicalKey}', not "
-                        + $"'{plan.TargetPrefab.CanonicalKey}'."
+                        + $"'{manifest.TargetPrefab.Address}', not "
+                        + $"'{plan.TargetPrefab.Address}'."
                 );
                 fatal = true;
                 continue;
@@ -178,13 +176,6 @@ public static class PrefabPatchResolver
         if (
             manifest.TargetPrefab == null
             || string.IsNullOrWhiteSpace(manifest.TargetPrefab.Address)
-            || string.IsNullOrWhiteSpace(
-                manifest.TargetPrefab.SourceSerializedFileName
-            )
-            || manifest.TargetPrefab.SourcePathId == 0
-            || string.IsNullOrWhiteSpace(
-                manifest.TargetPrefab.StructuralFingerprint
-            )
         )
         {
             Add(
@@ -193,8 +184,26 @@ public static class PrefabPatchResolver
                 "PM-PREFAB-TARGET-IDENTITY",
                 manifest.PatchId,
                 null,
-                $"Patch '{manifest.PatchId}' has an incomplete canonical "
-                    + "prefab identity or structural fingerprint."
+                $"Patch '{manifest.PatchId}' has no target Addressables key."
+            );
+            return false;
+        }
+
+        if (
+            manifest.TargetPrefab.HasCanonicalMetadata
+            && !manifest.TargetPrefab.IsCanonical
+        )
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-TARGET-IDENTITY",
+                manifest.PatchId,
+                null,
+                $"Patch '{manifest.PatchId}' contains partial compiler "
+                    + "identity metadata. Imperative patches should specify "
+                    + "only the Addressables key; visual manifests must contain "
+                    + "a complete CAB/path identity and structural fingerprint."
             );
             return false;
         }
@@ -223,6 +232,30 @@ public static class PrefabPatchResolver
 
         manifest.ManifestHash = calculatedHash;
         return true;
+    }
+
+    private static bool TargetsMatch(
+        PrefabPatchPrefabIdentity left,
+        PrefabPatchPrefabIdentity right
+    )
+    {
+        if (
+            left == null
+            || right == null
+            || !string.Equals(
+                left.Address,
+                right.Address,
+                StringComparison.Ordinal
+            )
+        )
+            return false;
+        return !left.IsCanonical
+            || !right.IsCanonical
+            || string.Equals(
+                left.CanonicalKey,
+                right.CanonicalKey,
+                StringComparison.Ordinal
+            );
     }
 
     private static void FilterModConstraints(

--- a/Runtime/PrefabPatching/PrefabPatchResolver.cs
+++ b/Runtime/PrefabPatching/PrefabPatchResolver.cs
@@ -140,6 +140,7 @@ public static class PrefabPatchResolver
         if (
             string.IsNullOrWhiteSpace(manifest.PatchId)
             || manifest.PatchId.IndexOf(':') <= 0
+            || string.IsNullOrWhiteSpace(manifest.PatchName)
         )
         {
             Add(
@@ -148,7 +149,8 @@ public static class PrefabPatchResolver
                 "PM-PREFAB-PATCH-ID",
                 manifest.PatchId,
                 null,
-                "Prefab patch IDs must be namespaced as 'mod-id:patch-id'."
+                "Prefab patch ownership has not been bound from its "
+                    + "containing mod."
             );
             return false;
         }

--- a/Runtime/PrefabPatching/PrefabPatchResolver.cs
+++ b/Runtime/PrefabPatching/PrefabPatchResolver.cs
@@ -1,0 +1,842 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Deterministic dependency, ordering, target, and conflict resolver for the
+/// prefab asset domain. It does not execute Unity mutations.
+/// </summary>
+public static class PrefabPatchResolver
+{
+    public static PrefabPatchResolvedPlan Resolve(
+        IEnumerable<PrefabPatchManifest> source,
+        ISet<string> activeModIds,
+        string unityVersion,
+        string targetPlatform
+    )
+    {
+        var manifests = source
+            .Where(manifest => manifest != null)
+            .OrderBy(manifest => manifest.PatchId, StringComparer.Ordinal)
+            .ToList();
+        var plan = new PrefabPatchResolvedPlan
+        {
+            ResolvedUtcTicks = DateTime.UtcNow.Ticks
+        };
+        if (manifests.Count == 0)
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-NO-PATCHES",
+                null,
+                null,
+                "No prefab patch manifests were supplied."
+            );
+            return plan;
+        }
+
+        plan.TargetPrefab = manifests[0].TargetPrefab;
+        var address = plan.TargetPrefab?.Address;
+        var fatal = false;
+        var byId = new Dictionary<string, PrefabPatchManifest>(
+            StringComparer.Ordinal
+        );
+        foreach (var manifest in manifests)
+        {
+            if (!ValidateManifest(manifest, plan))
+            {
+                fatal = true;
+                continue;
+            }
+
+            if (
+                !string.Equals(
+                    manifest.TargetPrefab.CanonicalKey,
+                    plan.TargetPrefab.CanonicalKey,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                Add(
+                    plan,
+                    PrefabPatchDiagnosticSeverity.Error,
+                    "PM-PREFAB-MIXED-TARGET",
+                    manifest.PatchId,
+                    null,
+                    $"Patch '{manifest.PatchId}' targets "
+                        + $"'{manifest.TargetPrefab.CanonicalKey}', not "
+                        + $"'{plan.TargetPrefab.CanonicalKey}'."
+                );
+                fatal = true;
+                continue;
+            }
+
+            if (!byId.TryAdd(manifest.PatchId, manifest))
+            {
+                Add(
+                    plan,
+                    PrefabPatchDiagnosticSeverity.Error,
+                    "PM-PREFAB-DUPLICATE-PATCH-ID",
+                    manifest.PatchId,
+                    null,
+                    $"Patch ID '{manifest.PatchId}' is registered more than once."
+                );
+                fatal = true;
+            }
+        }
+
+        var enabled = new HashSet<string>(byId.Keys, StringComparer.Ordinal);
+        FilterModConstraints(byId, enabled, activeModIds, plan);
+        FilterPatchConstraints(byId, enabled, plan);
+
+        var ordered = Order(byId, enabled, plan, ref fatal);
+        plan.OrderedPatchIds = ordered
+            .Select(manifest => manifest.PatchId)
+            .ToArray();
+
+        ValidateAndFlattenOperations(ordered, plan, ref fatal);
+        plan.InputHash = BuildInputHash(
+            ordered,
+            plan.TargetPrefab,
+            plan.Diagnostics,
+            unityVersion,
+            targetPlatform
+        );
+        plan.CacheKey = PrefabPatchJson.Sha256(
+            $"{address}|{plan.TargetPrefab?.CanonicalKey}|{plan.InputHash}"
+        );
+        plan.IsValid = !fatal;
+        return plan;
+    }
+
+    private static bool ValidateManifest(
+        PrefabPatchManifest manifest,
+        PrefabPatchResolvedPlan plan
+    )
+    {
+        if (
+            manifest.SchemaVersion != PrefabPatchSchema.Version
+            || manifest.ComposerVersion != PrefabPatchSchema.ComposerVersion
+        )
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-SCHEMA",
+                manifest.PatchId,
+                null,
+                $"Patch '{manifest.PatchId}' uses schema "
+                    + $"{manifest.SchemaVersion}/composer "
+                    + $"{manifest.ComposerVersion}; runtime requires "
+                    + $"{PrefabPatchSchema.Version}/"
+                    + $"{PrefabPatchSchema.ComposerVersion}."
+            );
+            return false;
+        }
+
+        if (
+            string.IsNullOrWhiteSpace(manifest.PatchId)
+            || manifest.PatchId.IndexOf(':') <= 0
+        )
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-PATCH-ID",
+                manifest.PatchId,
+                null,
+                "Prefab patch IDs must be namespaced as 'mod-id:patch-id'."
+            );
+            return false;
+        }
+
+        if (
+            string.IsNullOrWhiteSpace(manifest.ModId)
+            || !manifest.PatchId.StartsWith(
+                manifest.ModId + ":",
+                StringComparison.Ordinal
+            )
+        )
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-MOD-NAMESPACE",
+                manifest.PatchId,
+                null,
+                $"Patch '{manifest.PatchId}' is not namespaced to owning mod "
+                    + $"'{manifest.ModId}'."
+            );
+            return false;
+        }
+
+        if (
+            manifest.TargetPrefab == null
+            || string.IsNullOrWhiteSpace(manifest.TargetPrefab.Address)
+            || string.IsNullOrWhiteSpace(
+                manifest.TargetPrefab.SourceSerializedFileName
+            )
+            || manifest.TargetPrefab.SourcePathId == 0
+            || string.IsNullOrWhiteSpace(
+                manifest.TargetPrefab.StructuralFingerprint
+            )
+        )
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-TARGET-IDENTITY",
+                manifest.PatchId,
+                null,
+                $"Patch '{manifest.PatchId}' has an incomplete canonical "
+                    + "prefab identity or structural fingerprint."
+            );
+            return false;
+        }
+
+        var calculatedHash = PrefabPatchJson.CalculateManifestHash(manifest);
+        if (
+            !string.IsNullOrWhiteSpace(manifest.ManifestHash)
+            && !string.Equals(
+                calculatedHash,
+                manifest.ManifestHash,
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            Add(
+                plan,
+                PrefabPatchDiagnosticSeverity.Error,
+                "PM-PREFAB-MANIFEST-HASH",
+                manifest.PatchId,
+                null,
+                $"Patch '{manifest.PatchId}' manifest hash does not match its "
+                    + "normalized content."
+            );
+            return false;
+        }
+
+        manifest.ManifestHash = calculatedHash;
+        return true;
+    }
+
+    private static void FilterModConstraints(
+        IReadOnlyDictionary<string, PrefabPatchManifest> byId,
+        ISet<string> enabled,
+        ISet<string> activeModIds,
+        PrefabPatchResolvedPlan plan
+    )
+    {
+        foreach (var manifest in byId.Values.OrderBy(
+                     value => value.PatchId,
+                     StringComparer.Ordinal
+                 ))
+        {
+            var missing = Safe(manifest.NeedsMods)
+                .Where(id => !activeModIds.Contains(id))
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToArray();
+            if (missing.Length > 0)
+            {
+                enabled.Remove(manifest.PatchId);
+                Add(
+                    plan,
+                    PrefabPatchDiagnosticSeverity.Error,
+                    "PM-PREFAB-MISSING-MOD",
+                    manifest.PatchId,
+                    null,
+                    $"Disabled '{manifest.PatchId}': missing required mod(s) "
+                        + string.Join(", ", missing) + "."
+                );
+                continue;
+            }
+
+            var conflicts = Safe(manifest.ConflictsMods)
+                .Where(activeModIds.Contains)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToArray();
+            if (conflicts.Length > 0)
+            {
+                enabled.Remove(manifest.PatchId);
+                Add(
+                    plan,
+                    PrefabPatchDiagnosticSeverity.Error,
+                    "PM-PREFAB-CONFLICTING-MOD",
+                    manifest.PatchId,
+                    null,
+                    $"Disabled '{manifest.PatchId}': conflicting mod(s) "
+                        + string.Join(", ", conflicts) + " are active."
+                );
+            }
+        }
+    }
+
+    private static void FilterPatchConstraints(
+        IReadOnlyDictionary<string, PrefabPatchManifest> byId,
+        ISet<string> enabled,
+        PrefabPatchResolvedPlan plan
+    )
+    {
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var patchId in enabled.OrderBy(
+                         id => id,
+                         StringComparer.Ordinal
+                     ).ToArray())
+            {
+                var manifest = byId[patchId];
+                var missing = Safe(manifest.NeedsPatches)
+                    .Where(id => !enabled.Contains(id))
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToArray();
+                if (missing.Length > 0)
+                {
+                    enabled.Remove(patchId);
+                    changed = true;
+                    Add(
+                        plan,
+                        PrefabPatchDiagnosticSeverity.Error,
+                        "PM-PREFAB-MISSING-PATCH",
+                        patchId,
+                        null,
+                        $"Disabled '{patchId}': missing required patch(es) "
+                            + string.Join(", ", missing) + "."
+                    );
+                    continue;
+                }
+
+                var conflicts = Safe(manifest.ConflictsPatches)
+                    .Where(enabled.Contains)
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToArray();
+                if (conflicts.Length > 0)
+                {
+                    enabled.Remove(patchId);
+                    changed = true;
+                    Add(
+                        plan,
+                        PrefabPatchDiagnosticSeverity.Error,
+                        "PM-PREFAB-CONFLICTING-PATCH",
+                        patchId,
+                        null,
+                        $"Disabled '{patchId}': conflicting patch(es) "
+                            + string.Join(", ", conflicts) + " are active."
+                    );
+                }
+            }
+        } while (changed);
+    }
+
+    private static List<PrefabPatchManifest> Order(
+        IReadOnlyDictionary<string, PrefabPatchManifest> byId,
+        ISet<string> enabled,
+        PrefabPatchResolvedPlan plan,
+        ref bool fatal
+    )
+    {
+        var result = new List<PrefabPatchManifest>();
+        foreach (PrefabPatchPass pass in Enum.GetValues(typeof(PrefabPatchPass)))
+        {
+            foreach (
+                PrefabPatchOrdering bucket in Enum.GetValues(
+                    typeof(PrefabPatchOrdering)
+                )
+            )
+            {
+                var members = enabled
+                    .Select(id => byId[id])
+                    .Where(
+                        manifest =>
+                            manifest.Pass == pass && manifest.Ordering == bucket
+                    )
+                    .ToDictionary(
+                        manifest => manifest.PatchId,
+                        StringComparer.Ordinal
+                    );
+                var incoming = members.Keys.ToDictionary(
+                    id => id,
+                    _ => new HashSet<string>(StringComparer.Ordinal),
+                    StringComparer.Ordinal
+                );
+                var outgoing = members.Keys.ToDictionary(
+                    id => id,
+                    _ => new HashSet<string>(StringComparer.Ordinal),
+                    StringComparer.Ordinal
+                );
+
+                foreach (var manifest in members.Values)
+                {
+                    foreach (var dependency in Safe(manifest.NeedsPatches))
+                    {
+                        if (!enabled.Contains(dependency))
+                            continue;
+                        var dependencyManifest = byId[dependency];
+                        if (
+                            Rank(dependencyManifest) > Rank(manifest)
+                        )
+                        {
+                            Add(
+                                plan,
+                                PrefabPatchDiagnosticSeverity.Error,
+                                "PM-PREFAB-DEPENDENCY-ORDER",
+                                manifest.PatchId,
+                                null,
+                                $"Patch '{manifest.PatchId}' requires later "
+                                    + $"patch '{dependency}'."
+                            );
+                            fatal = true;
+                        }
+                        else if (members.ContainsKey(dependency))
+                        {
+                            AddEdge(
+                                dependency,
+                                manifest.PatchId,
+                                incoming,
+                                outgoing
+                            );
+                        }
+                    }
+
+                    AddSameBucketEdges(
+                        manifest,
+                        manifest.AfterPatches,
+                        after: true,
+                        members,
+                        incoming,
+                        outgoing,
+                        plan
+                    );
+                    AddSameBucketEdges(
+                        manifest,
+                        manifest.BeforePatches,
+                        after: false,
+                        members,
+                        incoming,
+                        outgoing,
+                        plan
+                    );
+                    AddModEdges(
+                        manifest,
+                        manifest.AfterMods,
+                        after: true,
+                        members,
+                        incoming,
+                        outgoing
+                    );
+                    AddModEdges(
+                        manifest,
+                        manifest.BeforeMods,
+                        after: false,
+                        members,
+                        incoming,
+                        outgoing
+                    );
+                }
+
+                var ready = new SortedSet<string>(
+                    incoming
+                        .Where(pair => pair.Value.Count == 0)
+                        .Select(pair => pair.Key),
+                    StringComparer.Ordinal
+                );
+                var emitted = new HashSet<string>(StringComparer.Ordinal);
+                while (ready.Count > 0)
+                {
+                    var id = ready.Min;
+                    ready.Remove(id);
+                    emitted.Add(id);
+                    result.Add(members[id]);
+                    foreach (var next in outgoing[id].OrderBy(
+                                 value => value,
+                                 StringComparer.Ordinal
+                             ))
+                    {
+                        incoming[next].Remove(id);
+                        if (incoming[next].Count == 0)
+                            ready.Add(next);
+                    }
+                }
+
+                var cyclic = members.Keys
+                    .Where(id => !emitted.Contains(id))
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToArray();
+                if (cyclic.Length > 0)
+                {
+                    Add(
+                        plan,
+                        PrefabPatchDiagnosticSeverity.Error,
+                        "PM-PREFAB-ORDER-CYCLE",
+                        null,
+                        null,
+                        "Ordering cycle among prefab patches: "
+                            + string.Join(", ", cyclic) + "."
+                    );
+                    fatal = true;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static void ValidateAndFlattenOperations(
+        IReadOnlyList<PrefabPatchManifest> ordered,
+        PrefabPatchResolvedPlan plan,
+        ref bool fatal
+    )
+    {
+        var patchOrder = ordered
+            .Select((manifest, index) => (manifest.PatchId, index))
+            .ToDictionary(pair => pair.PatchId, pair => pair.index);
+        var introduced = new Dictionary<string, string>(StringComparer.Ordinal);
+        var writes = new Dictionary<string, PrefabPatchOperation>(
+            StringComparer.Ordinal
+        );
+
+        foreach (var manifest in ordered)
+        {
+            var needs = new HashSet<string>(
+                Safe(manifest.NeedsPatches),
+                StringComparer.Ordinal
+            );
+            foreach (
+                var operation in manifest.Operations
+                    .Where(value => value != null)
+                    .OrderBy(value => value.OperationId, StringComparer.Ordinal)
+            )
+            {
+                operation.PatchId = manifest.PatchId;
+                if (string.IsNullOrWhiteSpace(operation.OperationId))
+                {
+                    Add(
+                        plan,
+                        PrefabPatchDiagnosticSeverity.Error,
+                        "PM-PREFAB-OPERATION-ID",
+                        manifest.PatchId,
+                        null,
+                        $"Patch '{manifest.PatchId}' contains an operation "
+                            + "without an ID."
+                    );
+                    fatal = true;
+                    continue;
+                }
+
+                if (
+                    operation.Kind != PrefabPatchOperationKind.AddObject
+                    && operation.Target == null
+                )
+                {
+                    Add(
+                        plan,
+                        PrefabPatchDiagnosticSeverity.Error,
+                        "PM-PREFAB-MISSING-TARGET",
+                        manifest.PatchId,
+                        operation.OperationId,
+                        $"Operation '{operation.OperationId}' has no target."
+                    );
+                    fatal = true;
+                    continue;
+                }
+
+                if (
+                    operation.Target?.Kind
+                    == PrefabPatchTargetKind.PatchOwned
+                )
+                {
+                    var owner = operation.Target.OwnerPatchId;
+                    var objectKey = $"{owner}:{operation.Target.ObjectId}";
+                    if (
+                        !string.Equals(
+                            owner,
+                            manifest.PatchId,
+                            StringComparison.Ordinal
+                        )
+                        && !needs.Contains(owner)
+                    )
+                    {
+                        Add(
+                            plan,
+                            PrefabPatchDiagnosticSeverity.Error,
+                            "PM-PREFAB-OWNER-NOT-REQUIRED",
+                            manifest.PatchId,
+                            operation.OperationId,
+                            $"Operation '{operation.OperationId}' targets "
+                                + $"'{objectKey}' but does not require owning "
+                                + $"patch '{owner}'."
+                        );
+                        fatal = true;
+                        continue;
+                    }
+
+                    if (
+                        !introduced.ContainsKey(objectKey)
+                        || patchOrder[owner] >= patchOrder[manifest.PatchId]
+                    )
+                    {
+                        Add(
+                            plan,
+                            PrefabPatchDiagnosticSeverity.Error,
+                            "PM-PREFAB-PATCH-OWNED-TARGET",
+                            manifest.PatchId,
+                            operation.OperationId,
+                            $"Patch-owned target '{objectKey}' is not introduced "
+                                + "by an earlier required operation."
+                        );
+                        fatal = true;
+                        continue;
+                    }
+                }
+
+                if (operation.Kind == PrefabPatchOperationKind.AddObject)
+                {
+                    var objectId = operation.AddedObject?.ObjectId;
+                    var objectKey = $"{manifest.PatchId}:{objectId}";
+                    if (string.IsNullOrWhiteSpace(objectId))
+                    {
+                        Add(
+                            plan,
+                            PrefabPatchDiagnosticSeverity.Error,
+                            "PM-PREFAB-ADDED-OBJECT-ID",
+                            manifest.PatchId,
+                            operation.OperationId,
+                            $"Added object operation '{operation.OperationId}' "
+                                + "has no patch-local object ID."
+                        );
+                        fatal = true;
+                        continue;
+                    }
+
+                    if (!introduced.TryAdd(objectKey, operation.OperationId))
+                    {
+                        Add(
+                            plan,
+                            PrefabPatchDiagnosticSeverity.Error,
+                            "PM-PREFAB-DUPLICATE-OBJECT-ID",
+                            manifest.PatchId,
+                            operation.OperationId,
+                            $"Patch-owned object '{objectKey}' is introduced "
+                                + "more than once."
+                        );
+                        fatal = true;
+                        continue;
+                    }
+                }
+
+                var conflictKey = operation.ConflictKey;
+                if (
+                    IsWrite(operation.Kind)
+                    && writes.TryGetValue(conflictKey, out var previous)
+                )
+                {
+                    if (
+                        string.Equals(
+                            OperationPayload(previous),
+                            OperationPayload(operation),
+                            StringComparison.Ordinal
+                        )
+                    )
+                    {
+                        Add(
+                            plan,
+                            PrefabPatchDiagnosticSeverity.Info,
+                            "PM-PREFAB-IDENTICAL-WRITE",
+                            manifest.PatchId,
+                            operation.OperationId,
+                            $"'{manifest.PatchId}' repeats the identical write "
+                                + $"from '{previous.PatchId}' to '{conflictKey}'."
+                        );
+                    }
+                    else
+                    {
+                        Add(
+                            plan,
+                            PrefabPatchDiagnosticSeverity.Warning,
+                            "PM-PREFAB-SOFT-CONFLICT",
+                            manifest.PatchId,
+                            operation.OperationId,
+                            $"Different writes target '{conflictKey}'. "
+                                + $"Deterministic order selects "
+                                + $"'{manifest.PatchId}' over "
+                                + $"'{previous.PatchId}'."
+                        );
+                    }
+                }
+
+                if (IsWrite(operation.Kind))
+                    writes[conflictKey] = operation;
+                plan.Operations.Add(operation);
+            }
+        }
+    }
+
+    private static string BuildInputHash(
+        IReadOnlyList<PrefabPatchManifest> ordered,
+        PrefabPatchPrefabIdentity target,
+        IReadOnlyList<PrefabPatchDiagnostic> diagnostics,
+        string unityVersion,
+        string targetPlatform
+    )
+    {
+        var value = new
+        {
+            UnityVersion = unityVersion,
+            TargetPlatform = targetPlatform,
+            SchemaVersion = PrefabPatchSchema.Version,
+            ComposerVersion = PrefabPatchSchema.ComposerVersion,
+            Target = target,
+            OrderedPatches = ordered.Select(
+                manifest => new
+                {
+                    manifest.PatchId,
+                    manifest.ManifestHash,
+                    manifest.ConfigurationInputs
+                }
+            ),
+            Resolution = diagnostics.Select(
+                diagnostic => new
+                {
+                    diagnostic.Severity,
+                    diagnostic.Code,
+                    diagnostic.PatchId,
+                    diagnostic.OperationId,
+                    diagnostic.Message
+                }
+            )
+        };
+        return PrefabPatchJson.Sha256(PrefabPatchJson.Serialize(value));
+    }
+
+    private static void AddSameBucketEdges(
+        PrefabPatchManifest manifest,
+        IEnumerable<string> ids,
+        bool after,
+        IReadOnlyDictionary<string, PrefabPatchManifest> members,
+        IDictionary<string, HashSet<string>> incoming,
+        IDictionary<string, HashSet<string>> outgoing,
+        PrefabPatchResolvedPlan plan
+    )
+    {
+        foreach (var id in Safe(ids))
+        {
+            if (!members.ContainsKey(id))
+            {
+                Add(
+                    plan,
+                    PrefabPatchDiagnosticSeverity.Info,
+                    "PM-PREFAB-CROSS-BUCKET-ORDER-IGNORED",
+                    manifest.PatchId,
+                    null,
+                    $"Ordering relation between '{manifest.PatchId}' and "
+                        + $"'{id}' is absent or crosses a pass/bucket and was "
+                        + "ignored."
+                );
+                continue;
+            }
+
+            AddEdge(
+                after ? id : manifest.PatchId,
+                after ? manifest.PatchId : id,
+                incoming,
+                outgoing
+            );
+        }
+    }
+
+    private static void AddModEdges(
+        PrefabPatchManifest manifest,
+        IEnumerable<string> modIds,
+        bool after,
+        IReadOnlyDictionary<string, PrefabPatchManifest> members,
+        IDictionary<string, HashSet<string>> incoming,
+        IDictionary<string, HashSet<string>> outgoing
+    )
+    {
+        foreach (var modId in Safe(modIds))
+        {
+            foreach (
+                var other in members.Values.Where(
+                    value =>
+                        string.Equals(
+                            value.ModId,
+                            modId,
+                            StringComparison.Ordinal
+                        )
+                        && value.PatchId != manifest.PatchId
+                )
+            )
+            {
+                AddEdge(
+                    after ? other.PatchId : manifest.PatchId,
+                    after ? manifest.PatchId : other.PatchId,
+                    incoming,
+                    outgoing
+                );
+            }
+        }
+    }
+
+    private static void AddEdge(
+        string before,
+        string after,
+        IDictionary<string, HashSet<string>> incoming,
+        IDictionary<string, HashSet<string>> outgoing
+    )
+    {
+        if (before == after)
+            return;
+        if (outgoing[before].Add(after))
+            incoming[after].Add(before);
+    }
+
+    private static int Rank(PrefabPatchManifest manifest) =>
+        ((int)manifest.Pass * 3) + (int)manifest.Ordering;
+
+    private static bool IsWrite(PrefabPatchOperationKind kind) =>
+        kind == PrefabPatchOperationKind.SetValue
+        || kind == PrefabPatchOperationKind.SetObjectReference
+        || kind == PrefabPatchOperationKind.SetActive
+        || kind == PrefabPatchOperationKind.SuppressObject
+        || kind == PrefabPatchOperationKind.RemoveComponent;
+
+    private static string OperationPayload(PrefabPatchOperation operation) =>
+        PrefabPatchJson.Serialize(
+            new
+            {
+                operation.Kind,
+                operation.PropertyPath,
+                operation.Value,
+                operation.ObjectReference
+            }
+        );
+
+    private static IEnumerable<string> Safe(IEnumerable<string> values) =>
+        values ?? Array.Empty<string>();
+
+    private static void Add(
+        PrefabPatchResolvedPlan plan,
+        PrefabPatchDiagnosticSeverity severity,
+        string code,
+        string patchId,
+        string operationId,
+        string message
+    )
+    {
+        plan.Diagnostics.Add(
+            new PrefabPatchDiagnostic
+            {
+                Severity = severity,
+                Code = code,
+                TargetAddress = plan.TargetPrefab?.Address,
+                PatchId = patchId,
+                OperationId = operationId,
+                Message = message
+            }
+        );
+    }
+}

--- a/Runtime/PrefabPatching/PrefabPatchResolver.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e78a05a731189c4d8d14426c36b04e1

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -325,7 +325,7 @@ public static class PrefabPatchRuntime
             var group in manifests
                 .Where(value => value?.TargetPrefab != null)
                 .GroupBy(
-                    value => value.TargetPrefab.CanonicalKey,
+                    value => value.TargetPrefab.Address,
                     StringComparer.Ordinal
                 )
                 .OrderBy(group => group.Key, StringComparer.Ordinal)

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -50,6 +50,13 @@ public static class PrefabPatchRuntime
         public int RequestCount;
     }
 
+    private sealed class ManifestLocation
+    {
+        public IResourceLocation Location;
+        public string OwnerModId;
+        public string LocatorId;
+    }
+
     private const string PlanCacheDirectory = "./pm_cache/prefabs";
     private const string SummaryPath = "./pm_prefab_summary.log";
     private static readonly List<PrefabPatchManifest> Registered = new();
@@ -63,6 +70,13 @@ public static class PrefabPatchRuntime
     public static Metrics CurrentMetrics { get; private set; } = new();
     public static IReadOnlyDictionary<string, PrefabPatchResolvedPlan> Plans =>
         Entries.ToDictionary(pair => pair.Key, pair => pair.Value.Plan);
+#if UNITY_EDITOR
+    /// <summary>
+    /// Editor integration hook that maps a compiled manifest asset path to
+    /// the Mod authoring asset (and therefore swinfo ID) that owns it.
+    /// </summary>
+    public static Func<string, string> EditorManifestOwnerResolver { get; set; }
+#endif
 
     /// <summary>
     /// Registers a fluent or generated C# manifest before registration closes.
@@ -92,6 +106,19 @@ public static class PrefabPatchRuntime
         ISet<string> activeModIds,
         Action resolve,
         Action<string> reject
+    ) =>
+        DiscoverAndResolve(
+            activeModIds,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            resolve,
+            reject
+        );
+
+    public static void DiscoverAndResolve(
+        ISet<string> activeModIds,
+        IReadOnlyDictionary<string, string> manifestCatalogOwners,
+        Action resolve,
+        Action<string> reject
     )
     {
         var stopwatch = Stopwatch.StartNew();
@@ -112,65 +139,56 @@ public static class PrefabPatchRuntime
             );
             return;
 #else
-            var locations = FindManifestLocations();
+            var locations = FindManifestLocations(manifestCatalogOwners);
             if (locations.Count > 0)
             {
-                var manifestHandle = Addressables.LoadAssetsAsync<TextAsset>(
-                    locations,
-                    null
-                );
-                manifestHandle.Completed += operation =>
+                foreach (var source in locations)
                 {
+                    AsyncOperationHandle<TextAsset> manifestHandle = default;
                     try
                     {
-                        if (operation.Status != AsyncOperationStatus.Succeeded)
+                        manifestHandle = Addressables.LoadAssetAsync<TextAsset>(
+                            source.Location
+                        );
+                        var asset = manifestHandle.WaitForCompletion();
+                        if (
+                            manifestHandle.Status
+                                != AsyncOperationStatus.Succeeded
+                            || asset == null
+                        )
                         {
-                            throw operation.OperationException
+                            throw manifestHandle.OperationException
                                 ?? new InvalidOperationException(
                                     "Prefab patch manifest load failed."
                                 );
                         }
 
-                        foreach (
-                            var asset in operation
-                                .Result.Where(value => value != null)
-                        )
-                        {
-                            try
-                            {
-                                manifests.Add(
-                                    PrefabPatchJson.Deserialize<
-                                        PrefabPatchManifest
-                                    >(asset.text)
-                                );
-                            }
-                            catch (Exception exception)
-                            {
-                                throw new InvalidDataException(
-                                    $"Could not parse prefab patch manifest "
-                                        + $"'{asset.name}'.",
-                                    exception
-                                );
-                            }
-                        }
-
-                        ResolveDiscoveredManifests(
-                            manifests,
-                            activeModIds,
-                            stopwatch,
-                            resolve
+                        var manifest =
+                            PrefabPatchJson.Deserialize<PrefabPatchManifest>(
+                                asset.text
+                            );
+                        manifests.Add(
+                            PrefabPatchOwnership.Bind(
+                                manifest,
+                                source.OwnerModId
+                            )
                         );
                     }
                     catch (Exception exception)
                     {
-                        RejectDiscovery(stopwatch, reject, exception);
+                        throw new InvalidDataException(
+                            $"Could not load prefab patch manifest "
+                                + $"'{source.Location.PrimaryKey}' from "
+                                + $"catalog '{source.LocatorId}'.",
+                            exception
+                        );
                     }
                     finally
                     {
-                        Addressables.Release(operation);
+                        if (manifestHandle.IsValid())
+                            Addressables.Release(manifestHandle);
                     }
-                };
-                return;
+                }
             }
 
             ResolveDiscoveredManifests(
@@ -222,8 +240,17 @@ public static class PrefabPatchRuntime
                 );
             }
 
-            if (manifest != null)
-                yield return manifest;
+            if (manifest == null)
+                continue;
+            var owner = EditorManifestOwnerResolver?.Invoke(path);
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new InvalidDataException(
+                    $"Could not determine the owning Mod asset for prefab "
+                        + $"patch manifest '{path}'."
+                );
+            }
+            yield return PrefabPatchOwnership.Bind(manifest, owner);
         }
     }
 #endif
@@ -294,29 +321,79 @@ public static class PrefabPatchRuntime
         );
     }
 
-    private static List<IResourceLocation> FindManifestLocations()
+    private static List<ManifestLocation> FindManifestLocations(
+        IReadOnlyDictionary<string, string> catalogOwners
+    )
     {
         return Addressables.ResourceLocators
             .SelectMany(locator =>
-                locator.Locate(
+            {
+                if (
+                    locator == null
+                    || !locator.Locate(
                     PrefabPatchSchema.AddressablesLabel,
                     typeof(TextAsset),
                     out var locations
                 )
-                    ? locations
-                    : Array.Empty<IResourceLocation>()
-            )
-            .Where(location => location != null)
+                )
+                {
+                    return Array.Empty<ManifestLocation>();
+                }
+
+                string ownerModId = null;
+                catalogOwners?.TryGetValue(
+                    locator.LocatorId,
+                    out ownerModId
+                );
+                if (string.IsNullOrWhiteSpace(ownerModId))
+                {
+                    throw new InvalidDataException(
+                        $"Addressables catalog '{locator.LocatorId}' contains "
+                            + "prefab patch manifests but is not associated "
+                            + "with a loaded mod swinfo descriptor."
+                    );
+                }
+                return locations
+                    .Where(location => location != null)
+                    .Select(location => new ManifestLocation
+                    {
+                        Location = location,
+                        OwnerModId = ownerModId,
+                        LocatorId = locator.LocatorId
+                    });
+            })
             .GroupBy(
-                location =>
-                    $"{location.ProviderId}\0{location.InternalId}\0"
-                    + $"{location.PrimaryKey}\0"
-                    + $"{location.ResourceType?.AssemblyQualifiedName}",
+                source =>
+                    $"{source.Location.ProviderId}\0"
+                    + $"{source.Location.InternalId}\0"
+                    + $"{source.Location.PrimaryKey}\0"
+                    + $"{source.Location.ResourceType?.AssemblyQualifiedName}",
                 StringComparer.Ordinal
             )
-            .Select(group => group.First())
-            .OrderBy(location => location.PrimaryKey, StringComparer.Ordinal)
-            .ThenBy(location => location.InternalId, StringComparer.Ordinal)
+            .Select(group =>
+            {
+                var owners = group
+                    .Select(value => value.OwnerModId)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                if (owners.Length != 1)
+                {
+                    throw new InvalidDataException(
+                        $"Prefab patch location '{group.Key}' is exposed by "
+                            + "multiple owning mods: "
+                            + string.Join(", ", owners)
+                    );
+                }
+                return group.First();
+            })
+            .OrderBy(
+                source => source.Location.PrimaryKey,
+                StringComparer.Ordinal
+            )
+            .ThenBy(
+                source => source.Location.InternalId,
+                StringComparer.Ordinal
+            )
             .ToList();
     }
 

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -398,7 +398,13 @@ public static class PrefabPatchRuntime
             foreach (
                 var reference in entry.Plan.Operations
                     .SelectMany(GetReferences)
-                    .Where(value => value != null)
+                    .Where(
+                        value =>
+                            value != null
+                            && value.Kind
+                            == PrefabPatchObjectReferenceKind.Addressable
+                            && !string.IsNullOrWhiteSpace(value.Address)
+                    )
                     .GroupBy(value => value.Address, StringComparer.Ordinal)
                     .Select(group => group.First())
                     .OrderBy(value => value.Address, StringComparer.Ordinal)
@@ -549,8 +555,14 @@ public static class PrefabPatchRuntime
     {
         if (operation.ObjectReference != null)
             yield return operation.ObjectReference;
-        if (operation.AddedComponent?.Mesh != null)
-            yield return operation.AddedComponent.Mesh;
+        foreach (
+            var reference in operation.AddedComponent?.References
+                ?? Enumerable.Empty<PrefabPatchSerializedReference>()
+        )
+        {
+            if (reference?.Reference != null)
+                yield return reference.Reference;
+        }
         if (operation.AddedObject == null)
             yield break;
         foreach (var reference in GetReferences(operation.AddedObject))
@@ -563,8 +575,14 @@ public static class PrefabPatchRuntime
     {
         foreach (var component in fragment.Components)
         {
-            if (component.Mesh != null)
-                yield return component.Mesh;
+            foreach (
+                var reference in component.References
+                    ?? Enumerable.Empty<PrefabPatchSerializedReference>()
+            )
+            {
+                if (reference?.Reference != null)
+                    yield return reference.Reference;
+            }
         }
 
         foreach (var child in fragment.Children)

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -54,6 +54,7 @@ public static class PrefabPatchRuntime
         StringComparer.Ordinal
     );
     private static PrefabPatchResourceLocator _locator;
+    private static GameObject _effectivePrefabRoot;
 
     public static bool RegistrationOpen { get; private set; } = true;
     public static Metrics CurrentMetrics { get; private set; } = new();
@@ -105,91 +106,137 @@ public static class PrefabPatchRuntime
                     locations,
                     null
                 );
-                var assets = manifestHandle.WaitForCompletion();
-                if (manifestHandle.Status != AsyncOperationStatus.Succeeded)
-                {
-                    throw manifestHandle.OperationException
-                        ?? new InvalidOperationException(
-                            "Prefab patch manifest load failed."
-                        );
-                }
-
-                foreach (var asset in assets.Where(value => value != null))
+                manifestHandle.Completed += operation =>
                 {
                     try
                     {
-                        manifests.Add(
-                            PrefabPatchJson.Deserialize<PrefabPatchManifest>(
-                                asset.text
-                            )
+                        if (operation.Status != AsyncOperationStatus.Succeeded)
+                        {
+                            throw operation.OperationException
+                                ?? new InvalidOperationException(
+                                    "Prefab patch manifest load failed."
+                                );
+                        }
+
+                        foreach (
+                            var asset in operation
+                                .Result.Where(value => value != null)
+                        )
+                        {
+                            try
+                            {
+                                manifests.Add(
+                                    PrefabPatchJson.Deserialize<
+                                        PrefabPatchManifest
+                                    >(asset.text)
+                                );
+                            }
+                            catch (Exception exception)
+                            {
+                                throw new InvalidDataException(
+                                    $"Could not parse prefab patch manifest "
+                                        + $"'{asset.name}'.",
+                                    exception
+                                );
+                            }
+                        }
+
+                        ResolveDiscoveredManifests(
+                            manifests,
+                            activeModIds,
+                            stopwatch,
+                            resolve
                         );
                     }
                     catch (Exception exception)
                     {
-                        throw new InvalidDataException(
-                            $"Could not parse prefab patch manifest "
-                                + $"'{asset.name}'.",
-                            exception
-                        );
+                        RejectDiscovery(stopwatch, reject, exception);
                     }
-                }
-
-                Addressables.Release(manifestHandle);
-            }
-
-            CurrentMetrics.DiscoveredManifestCount = manifests.Count;
-            var cache = new PrefabPatchPlanCache(PlanCacheDirectory);
-            Entries.Clear();
-            foreach (
-                var group in manifests
-                    .Where(value => value?.TargetPrefab != null)
-                    .GroupBy(
-                        value => value.TargetPrefab.CanonicalKey,
-                        StringComparer.Ordinal
-                    )
-                    .OrderBy(group => group.Key, StringComparer.Ordinal)
-            )
-            {
-                var result = cache.LoadOrResolve(
-                    group,
-                    activeModIds,
-                    Application.unityVersion,
-                    Application.platform.ToString()
-                );
-                if (result.CacheHit)
-                    CurrentMetrics.CacheHitCount++;
-                else
-                    CurrentMetrics.CacheMissCount++;
-                if (
-                    result.Plan?.TargetPrefab != null
-                    && result.Plan.IsValid
-                )
-                {
-                    Entries[result.Plan.TargetPrefab.Address] = new Entry
+                    finally
                     {
-                        Plan = result.Plan
-                    };
-                }
+                        Addressables.Release(operation);
+                    }
+                };
+                return;
             }
 
-            CurrentMetrics.ResolvedPlanCount = Entries.Count;
-            WriteSummary();
-            stopwatch.Stop();
-            CurrentMetrics.StartupMilliseconds = stopwatch.ElapsedMilliseconds;
-            CurrentMetrics.MemoryAfterBytes =
-                Profiler.GetTotalAllocatedMemoryLong();
-            resolve();
+            ResolveDiscoveredManifests(
+                manifests,
+                activeModIds,
+                stopwatch,
+                resolve
+            );
         }
         catch (Exception exception)
         {
-            stopwatch.Stop();
-            CurrentMetrics.StartupMilliseconds = stopwatch.ElapsedMilliseconds;
-            UnityEngine.Debug.LogException(exception);
-            reject(
-                "Patch Manager prefab discovery failed: "
-                    + exception.Message
-            );
+            RejectDiscovery(stopwatch, reject, exception);
         }
+    }
+
+    private static void ResolveDiscoveredManifests(
+        IReadOnlyCollection<PrefabPatchManifest> manifests,
+        ISet<string> activeModIds,
+        Stopwatch stopwatch,
+        Action resolve
+    )
+    {
+        CurrentMetrics.DiscoveredManifestCount = manifests.Count;
+        var cache = new PrefabPatchPlanCache(PlanCacheDirectory);
+        Entries.Clear();
+        foreach (
+            var group in manifests
+                .Where(value => value?.TargetPrefab != null)
+                .GroupBy(
+                    value => value.TargetPrefab.CanonicalKey,
+                    StringComparer.Ordinal
+                )
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
+        )
+        {
+            var result = cache.LoadOrResolve(
+                group,
+                activeModIds,
+                Application.unityVersion,
+                Application.platform.ToString()
+            );
+            if (result.CacheHit)
+                CurrentMetrics.CacheHitCount++;
+            else
+                CurrentMetrics.CacheMissCount++;
+            if (
+                result.Plan?.TargetPrefab != null
+                && result.Plan.IsValid
+            )
+            {
+                Entries[result.Plan.TargetPrefab.Address] = new Entry
+                {
+                    Plan = result.Plan
+                };
+            }
+        }
+
+        CurrentMetrics.ResolvedPlanCount = Entries.Count;
+        WriteSummary();
+        stopwatch.Stop();
+        CurrentMetrics.StartupMilliseconds = stopwatch.ElapsedMilliseconds;
+        CurrentMetrics.MemoryAfterBytes =
+            Profiler.GetTotalAllocatedMemoryLong();
+        resolve();
+    }
+
+    private static void RejectDiscovery(
+        Stopwatch stopwatch,
+        Action<string> reject,
+        Exception exception
+    )
+    {
+        stopwatch.Stop();
+        CurrentMetrics.StartupMilliseconds = stopwatch.ElapsedMilliseconds;
+        UnityEngine.Debug.LogException(exception);
+        reject(
+            "Patch Manager prefab discovery failed: "
+                + exception.Message
+        );
     }
 
     private static List<IResourceLocation> FindManifestLocations()
@@ -324,14 +371,19 @@ public static class PrefabPatchRuntime
                 entry.References.Add(reference.Address, value);
             }
 
+            var effectivePrefab = CreateEffectivePrefab(stock);
             var result = PrefabPatchComposer.ApplySynchronously(
-                stock,
+                effectivePrefab,
                 entry.Plan,
                 entry.References
             );
             if (!result.Success)
+            {
+                Object.DestroyImmediate(effectivePrefab);
                 throw new InvalidOperationException(result.Failure);
-            entry.EffectivePrefab = stock;
+            }
+
+            entry.EffectivePrefab = effectivePrefab;
             stopwatch.Stop();
             CurrentMetrics.FirstCompositionMilliseconds +=
                 stopwatch.ElapsedMilliseconds;
@@ -345,7 +397,7 @@ public static class PrefabPatchRuntime
                 );
             CurrentMetrics.MemoryAfterBytes =
                 Profiler.GetTotalAllocatedMemoryLong();
-            prefab = stock;
+            prefab = effectivePrefab;
             return true;
         }
         catch (Exception exception)
@@ -360,6 +412,32 @@ public static class PrefabPatchRuntime
             WriteSummary();
             return false;
         }
+    }
+
+    private static GameObject CreateEffectivePrefab(GameObject stock)
+    {
+        if (_effectivePrefabRoot == null)
+        {
+            _effectivePrefabRoot = new GameObject(
+                "PatchManager Effective Prefabs"
+            );
+            _effectivePrefabRoot.hideFlags = HideFlags.HideAndDontSave;
+            _effectivePrefabRoot.SetActive(false);
+            Object.DontDestroyOnLoad(_effectivePrefabRoot);
+        }
+
+        // AssetBundle assets are read-only native objects. Patching them in
+        // place is not stable: Unity can restore removed components before a
+        // later instantiation. Keep an inactive, session-owned template
+        // instead. Parenting under an inactive root prevents prefab
+        // MonoBehaviours from initializing while the patch is composed.
+        var effectivePrefab = Object.Instantiate(
+            stock,
+            _effectivePrefabRoot.transform,
+            false
+        );
+        effectivePrefab.name = stock.name;
+        return effectivePrefab;
     }
 
     private static IResourceLocation ResolveOriginalLocation(
@@ -489,11 +567,42 @@ public static class PrefabPatchRuntime
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
     private static void ResetStaticState()
     {
+        ReleaseSessionResources();
         Registered.Clear();
         Entries.Clear();
         _locator = null;
         RegistrationOpen = true;
         CurrentMetrics = new Metrics();
+    }
+
+    /// <summary>
+    /// Releases effective prefab templates and the Addressables handles that
+    /// keep their stock assets and referenced objects alive.
+    /// </summary>
+    public static void ReleaseSessionResources()
+    {
+        foreach (var entry in Entries.Values)
+        {
+            if (entry.EffectivePrefab != null)
+                Object.DestroyImmediate(entry.EffectivePrefab);
+            entry.EffectivePrefab = null;
+
+            foreach (var handle in entry.ReferenceHandles)
+            {
+                if (handle.IsValid())
+                    handle.Release();
+            }
+
+            entry.ReferenceHandles.Clear();
+            entry.References.Clear();
+            if (entry.StockHandle.IsValid())
+                entry.StockHandle.Release();
+            entry.StockHandle = default;
+        }
+
+        if (_effectivePrefabRoot != null)
+            Object.DestroyImmediate(_effectivePrefabRoot);
+        _effectivePrefabRoot = null;
     }
 }
 
@@ -521,7 +630,6 @@ internal sealed class PrefabPatchResourceLocator :
         var address = key?.ToString();
         if (
             string.IsNullOrWhiteSpace(address)
-            || !_entries.ContainsKey(address)
             || (
                 type != typeof(object)
                 && type != typeof(Object)
@@ -534,16 +642,88 @@ internal sealed class PrefabPatchResourceLocator :
             return false;
         }
 
-        locations = new IResourceLocation[]
+        if (_entries.ContainsKey(address))
         {
-            new ResourceLocationBase(
-                "prefab-patch:" + address,
-                address,
-                typeof(PrefabPatchResourceProvider).FullName,
-                typeof(GameObject)
+            locations = new IResourceLocation[] { CreatePatchLocation(address) };
+            return true;
+        }
+
+        var resolved = new List<IResourceLocation>();
+        var identities = new HashSet<string>(StringComparer.Ordinal);
+        var replacedAny = false;
+        foreach (var locator in Addressables.ResourceLocators)
+        {
+            if (
+                !locator.Locate(key, typeof(GameObject), out var sourceLocations)
+                || sourceLocations == null
             )
-        };
-        return true;
+                continue;
+
+            foreach (var sourceLocation in sourceLocations)
+            {
+                var sourceAddress = sourceLocation?.PrimaryKey;
+                IResourceLocation resolvedLocation = sourceLocation;
+                if (
+                    !string.IsNullOrWhiteSpace(sourceAddress)
+                    && _entries.ContainsKey(sourceAddress)
+                )
+                {
+                    resolvedLocation = CreatePatchLocation(sourceAddress);
+                    replacedAny = true;
+                }
+
+                if (
+                    resolvedLocation != null
+                    && identities.Add(GetLocationIdentity(resolvedLocation))
+                )
+                    resolved.Add(resolvedLocation);
+            }
+        }
+
+        locations = replacedAny
+            ? resolved
+            : Array.Empty<IResourceLocation>();
+        return replacedAny;
+    }
+
+    private static IResourceLocation CreatePatchLocation(string address)
+    {
+        return new ResourceLocationBase(
+            "prefab-patch:" + address,
+            address,
+            typeof(PrefabPatchResourceProvider).FullName,
+            typeof(GameObject)
+        );
+    }
+
+    private static string GetLocationIdentity(IResourceLocation location)
+    {
+        if (
+            string.Equals(
+                location.ProviderId,
+                typeof(PrefabPatchResourceProvider).FullName,
+                StringComparison.Ordinal
+            )
+        )
+            return "patch|" + location.PrimaryKey;
+
+        var dependencies = location.Dependencies == null
+            ? string.Empty
+            : string.Join(
+                ";",
+                location.Dependencies.Select(dependency =>
+                    (dependency?.PrimaryKey ?? string.Empty)
+                    + "|"
+                    + (dependency?.InternalId ?? string.Empty)
+                )
+            );
+        return (location.PrimaryKey ?? string.Empty)
+            + "|"
+            + (location.InternalId ?? string.Empty)
+            + "|"
+            + (location.ResourceType?.AssemblyQualifiedName ?? string.Empty)
+            + "|"
+            + dependencies;
     }
 }
 

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -98,17 +98,8 @@ public static class PrefabPatchRuntime
         try
         {
             var manifests = new List<PrefabPatchManifest>(Registered);
-            var locationsHandle =
-                Addressables.LoadResourceLocationsAsync(
-                    PrefabPatchSchema.AddressablesLabel,
-                    typeof(TextAsset)
-                );
-            var locations = locationsHandle.WaitForCompletion();
-            if (
-                locationsHandle.Status == AsyncOperationStatus.Succeeded
-                && locations != null
-                && locations.Count > 0
-            )
+            var locations = FindManifestLocations();
+            if (locations.Count > 0)
             {
                 var manifestHandle = Addressables.LoadAssetsAsync<TextAsset>(
                     locations,
@@ -146,7 +137,6 @@ public static class PrefabPatchRuntime
                 Addressables.Release(manifestHandle);
             }
 
-            Addressables.Release(locationsHandle);
             CurrentMetrics.DiscoveredManifestCount = manifests.Count;
             var cache = new PrefabPatchPlanCache(PlanCacheDirectory);
             Entries.Clear();
@@ -200,6 +190,32 @@ public static class PrefabPatchRuntime
                     + exception.Message
             );
         }
+    }
+
+    private static List<IResourceLocation> FindManifestLocations()
+    {
+        return Addressables.ResourceLocators
+            .SelectMany(locator =>
+                locator.Locate(
+                    PrefabPatchSchema.AddressablesLabel,
+                    typeof(TextAsset),
+                    out var locations
+                )
+                    ? locations
+                    : Array.Empty<IResourceLocation>()
+            )
+            .Where(location => location != null)
+            .GroupBy(
+                location =>
+                    $"{location.ProviderId}\0{location.InternalId}\0"
+                    + $"{location.PrimaryKey}\0"
+                    + $"{location.ResourceType?.AssemblyQualifiedName}",
+                StringComparer.Ordinal
+            )
+            .Select(group => group.First())
+            .OrderBy(location => location.PrimaryKey, StringComparer.Ordinal)
+            .ThenBy(location => location.InternalId, StringComparer.Ordinal)
+            .ToList();
     }
 
     /// <summary>

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -9,9 +9,6 @@ using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.ResourceManagement.ResourceLocations;
 using UnityEngine.ResourceManagement.ResourceProviders;
 using UnityEngine.Profiling;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 using Object = UnityEngine.Object;
 
 namespace PatchManager.PrefabPatching;
@@ -81,6 +78,9 @@ public static class PrefabPatchRuntime
     public sealed class Metrics
     {
         public int DiscoveredManifestCount;
+        public int RegisteredManifestCount;
+        public int AddressableManifestCount;
+        public string[] ManifestSources = Array.Empty<string>();
         public int ResolvedPlanCount;
         public int CacheHitCount;
         public int CacheMissCount;
@@ -112,6 +112,7 @@ public static class PrefabPatchRuntime
         public IResourceLocation Location;
         public string OwnerModId;
         public string LocatorId;
+        public string Label;
     }
 
     private const string PlanCacheDirectory = "./pm_cache/prefabs";
@@ -126,13 +127,6 @@ public static class PrefabPatchRuntime
     public static Metrics CurrentMetrics { get; private set; } = new();
     public static IReadOnlyDictionary<string, PrefabPatchResolvedPlan> Plans =>
         Entries.ToDictionary(pair => pair.Key, pair => pair.Value.Plan);
-#if UNITY_EDITOR
-    /// <summary>
-    /// Editor integration hook that maps a compiled manifest asset path to
-    /// the Mod authoring asset (and therefore swinfo ID) that owns it.
-    /// </summary>
-    public static Func<string, string> EditorManifestOwnerResolver { get; set; }
-#endif
 
     /// <summary>
     /// Registers a fluent or generated C# manifest before registration closes.
@@ -165,14 +159,14 @@ public static class PrefabPatchRuntime
     ) =>
         DiscoverAndResolve(
             activeModIds,
-            new Dictionary<string, string>(StringComparer.Ordinal),
+            Array.Empty<PrefabPatchManifestSource>(),
             resolve,
             reject
         );
 
     public static void DiscoverAndResolve(
         ISet<string> activeModIds,
-        IReadOnlyDictionary<string, string> manifestCatalogOwners,
+        IReadOnlyCollection<PrefabPatchManifestSource> manifestSources,
         Action resolve,
         Action<string> reject
     )
@@ -185,17 +179,26 @@ public static class PrefabPatchRuntime
         try
         {
             var manifests = new List<PrefabPatchManifest>(Registered);
-#if UNITY_EDITOR
-            manifests.AddRange(LoadEditorProjectManifests());
-            ResolveDiscoveredManifests(
-                manifests,
-                activeModIds,
-                stopwatch,
-                resolve
-            );
-            return;
-#else
-            var locations = FindManifestLocations(manifestCatalogOwners);
+            CurrentMetrics.RegisteredManifestCount = Registered.Count;
+            CurrentMetrics.ManifestSources = (manifestSources
+                    ?? Array.Empty<PrefabPatchManifestSource>())
+                .Where(source =>
+                    source != null
+                    && !string.IsNullOrWhiteSpace(source.OwnerModId)
+                    && !string.IsNullOrWhiteSpace(
+                        source.AddressablesLabel
+                    )
+                )
+                .Select(source =>
+                    source.OwnerModId.Trim()
+                    + ": "
+                    + source.AddressablesLabel.Trim()
+                )
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray();
+            var locations = FindManifestLocations(manifestSources);
+            CurrentMetrics.AddressableManifestCount = locations.Count;
             if (locations.Count > 0)
             {
                 foreach (var source in locations)
@@ -235,7 +238,9 @@ public static class PrefabPatchRuntime
                         throw new InvalidDataException(
                             $"Could not load prefab patch manifest "
                                 + $"'{source.Location.PrimaryKey}' from "
-                                + $"catalog '{source.LocatorId}'.",
+                                + $"label '{source.Label}' owned by "
+                                + $"'{source.OwnerModId}' in catalog "
+                                + $"'{source.LocatorId}'.",
                             exception
                         );
                     }
@@ -253,63 +258,12 @@ public static class PrefabPatchRuntime
                 stopwatch,
                 resolve
             );
-#endif
         }
         catch (Exception exception)
         {
             RejectDiscovery(stopwatch, reject, exception);
         }
     }
-
-#if UNITY_EDITOR
-    private static IEnumerable<PrefabPatchManifest> LoadEditorProjectManifests()
-    {
-        foreach (
-            var path in AssetDatabase
-                .GetAllAssetPaths()
-                .Where(path =>
-                    path.EndsWith(
-                        ".prefabpatch.json",
-                        StringComparison.OrdinalIgnoreCase
-                    )
-                )
-                .OrderBy(path => path, StringComparer.Ordinal)
-        )
-        {
-            var asset = AssetDatabase.LoadAssetAtPath<TextAsset>(path);
-            if (asset == null)
-                continue;
-
-            PrefabPatchManifest manifest;
-            try
-            {
-                manifest =
-                    PrefabPatchJson.Deserialize<PrefabPatchManifest>(
-                        asset.text
-                    );
-            }
-            catch (Exception exception)
-            {
-                throw new InvalidDataException(
-                    $"Could not parse prefab patch manifest '{path}'.",
-                    exception
-                );
-            }
-
-            if (manifest == null)
-                continue;
-            var owner = EditorManifestOwnerResolver?.Invoke(path);
-            if (string.IsNullOrWhiteSpace(owner))
-            {
-                throw new InvalidDataException(
-                    $"Could not determine the owning Mod asset for prefab "
-                        + $"patch manifest '{path}'."
-                );
-            }
-            yield return PrefabPatchOwnership.Bind(manifest, owner);
-        }
-    }
-#endif
 
     private static void ResolveDiscoveredManifests(
         IReadOnlyCollection<PrefabPatchManifest> manifests,
@@ -378,46 +332,81 @@ public static class PrefabPatchRuntime
     }
 
     private static List<ManifestLocation> FindManifestLocations(
-        IReadOnlyDictionary<string, string> catalogOwners
+        IReadOnlyCollection<PrefabPatchManifestSource> manifestSources
     )
     {
-        return Addressables.ResourceLocators
-            .SelectMany(locator =>
+        var sources = (manifestSources
+                ?? Array.Empty<PrefabPatchManifestSource>())
+            .Where(source =>
+                source != null
+                && !string.IsNullOrWhiteSpace(source.OwnerModId)
+                && !string.IsNullOrWhiteSpace(source.AddressablesLabel)
+            )
+            .Select(source => new PrefabPatchManifestSource
             {
-                if (
-                    locator == null
-                    || !locator.Locate(
-                    PrefabPatchSchema.AddressablesLabel,
-                    typeof(TextAsset),
-                    out var locations
-                )
-                )
-                {
-                    return Array.Empty<ManifestLocation>();
-                }
-
-                string ownerModId = null;
-                catalogOwners?.TryGetValue(
-                    locator.LocatorId,
-                    out ownerModId
-                );
-                if (string.IsNullOrWhiteSpace(ownerModId))
-                {
-                    throw new InvalidDataException(
-                        $"Addressables catalog '{locator.LocatorId}' contains "
-                            + "prefab patch manifests but is not associated "
-                            + "with a loaded mod swinfo descriptor."
-                    );
-                }
-                return locations
-                    .Where(location => location != null)
-                    .Select(location => new ManifestLocation
-                    {
-                        Location = location,
-                        OwnerModId = ownerModId,
-                        LocatorId = locator.LocatorId
-                    });
+                OwnerModId = source.OwnerModId.Trim(),
+                AddressablesLabel = source.AddressablesLabel.Trim()
             })
+            .Distinct(PrefabPatchManifestSourceComparer.Instance)
+            .OrderBy(source => source.OwnerModId, StringComparer.Ordinal)
+            .ThenBy(
+                source => source.AddressablesLabel,
+                StringComparer.Ordinal
+            )
+            .ToArray();
+
+        foreach (
+            var duplicate in sources
+                .GroupBy(
+                    source => source.AddressablesLabel,
+                    StringComparer.Ordinal
+                )
+                .Where(group =>
+                    group.Select(source => source.OwnerModId)
+                        .Distinct(StringComparer.Ordinal)
+                        .Skip(1)
+                        .Any()
+                )
+        )
+        {
+            throw new InvalidDataException(
+                $"Prefab patch Addressables label '{duplicate.Key}' is "
+                    + "declared by multiple active mods: "
+                    + string.Join(
+                        ", ",
+                        duplicate.Select(source => source.OwnerModId)
+                            .Distinct(StringComparer.Ordinal)
+                    )
+            );
+        }
+
+        return sources
+            .SelectMany(source =>
+                Addressables.ResourceLocators.SelectMany(locator =>
+                {
+                    if (
+                        locator == null
+                        || !locator.Locate(
+                            source.AddressablesLabel,
+                            typeof(TextAsset),
+                            out var locations
+                        )
+                    )
+                    {
+                        return Array.Empty<ManifestLocation>();
+                    }
+
+                    return locations
+                        .Where(location => location != null)
+                        .Select(location => new ManifestLocation
+                        {
+                            Location = location,
+                            OwnerModId = source.OwnerModId,
+                            LocatorId = locator.LocatorId,
+                            Label = source.AddressablesLabel
+                        });
+                })
+            )
             .GroupBy(
                 source =>
                     $"{source.Location.ProviderId}\0"
@@ -446,11 +435,57 @@ public static class PrefabPatchRuntime
                 source => source.Location.PrimaryKey,
                 StringComparer.Ordinal
             )
+            .ThenBy(source => source.OwnerModId, StringComparer.Ordinal)
             .ThenBy(
                 source => source.Location.InternalId,
                 StringComparer.Ordinal
             )
             .ToList();
+    }
+
+    private sealed class PrefabPatchManifestSourceComparer :
+        IEqualityComparer<PrefabPatchManifestSource>
+    {
+        public static readonly PrefabPatchManifestSourceComparer Instance =
+            new();
+
+        public bool Equals(
+            PrefabPatchManifestSource left,
+            PrefabPatchManifestSource right
+        ) =>
+            ReferenceEquals(left, right)
+            || (
+                left != null
+                && right != null
+                && string.Equals(
+                    left.OwnerModId,
+                    right.OwnerModId,
+                    StringComparison.Ordinal
+                )
+                && string.Equals(
+                    left.AddressablesLabel,
+                    right.AddressablesLabel,
+                    StringComparison.Ordinal
+                )
+            );
+
+        public int GetHashCode(PrefabPatchManifestSource source)
+        {
+            if (source == null)
+                return 0;
+            unchecked
+            {
+                return (
+                        StringComparer.Ordinal.GetHashCode(
+                            source.OwnerModId ?? string.Empty
+                        )
+                        * 397
+                    )
+                    ^ StringComparer.Ordinal.GetHashCode(
+                        source.AddressablesLabel ?? string.Empty
+                    );
+            }
+        }
     }
 
     /// <summary>
@@ -733,10 +768,14 @@ public static class PrefabPatchRuntime
             $"    Schema: {PrefabPatchSchema.Version}",
             $"    Composer: {PrefabPatchSchema.ComposerVersion}",
             $"    Discovered Manifests: {CurrentMetrics.DiscoveredManifestCount}",
+            $"    Registered Manifests: {CurrentMetrics.RegisteredManifestCount}",
+            $"    Addressable Manifests: {CurrentMetrics.AddressableManifestCount}",
             $"    Resolved Plans: {CurrentMetrics.ResolvedPlanCount}",
             $"    Plan Cache Hits: {CurrentMetrics.CacheHitCount}",
             $"    Plan Cache Misses: {CurrentMetrics.CacheMissCount}"
         };
+        foreach (var source in CurrentMetrics.ManifestSources)
+            lines.Add($"    Manifest Source: {source}");
         foreach (
             var pair in Entries.OrderBy(
                 value => value.Key,

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -17,6 +17,63 @@ using Object = UnityEngine.Object;
 namespace PatchManager.PrefabPatching;
 
 /// <summary>
+/// Coordinates the ordinary and prefab-patch sections of Patch Manager's
+/// single human-readable summary log.
+/// </summary>
+public static class PatchManagerSummaryLog
+{
+    private const string SummaryPath = "./pm_summary.log";
+    private static readonly object Gate = new();
+    private static string _coreSummary;
+    private static string _prefabSummary;
+
+    public static void UpdateCoreSummary(string summary)
+    {
+        lock (Gate)
+        {
+            _coreSummary = Normalize(summary);
+            Write();
+        }
+    }
+
+    public static void UpdatePrefabSummary(string summary)
+    {
+        lock (Gate)
+        {
+            _prefabSummary = Normalize(summary);
+            Write();
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (Gate)
+        {
+            _coreSummary = null;
+            _prefabSummary = null;
+        }
+    }
+
+    private static string Normalize(string summary)
+    {
+        return string.IsNullOrWhiteSpace(summary)
+            ? null
+            : summary.TrimEnd();
+    }
+
+    private static void Write()
+    {
+        var sections = new[] { _coreSummary, _prefabSummary }
+            .Where(value => !string.IsNullOrEmpty(value));
+        File.WriteAllText(
+            SummaryPath,
+            string.Join(Environment.NewLine + Environment.NewLine, sections)
+                + Environment.NewLine
+        );
+    }
+}
+
+/// <summary>
 /// Public registry and lazy effective-prefab runtime for the prefab domain.
 /// </summary>
 public static class PrefabPatchRuntime
@@ -58,7 +115,6 @@ public static class PrefabPatchRuntime
     }
 
     private const string PlanCacheDirectory = "./pm_cache/prefabs";
-    private const string SummaryPath = "./pm_prefab_summary.log";
     private static readonly List<PrefabPatchManifest> Registered = new();
     private static readonly Dictionary<string, Entry> Entries = new(
         StringComparer.Ordinal
@@ -673,13 +729,13 @@ public static class PrefabPatchRuntime
     {
         var lines = new List<string>
         {
-            "Patch Manager prefab patch summary",
-            $"Schema: {PrefabPatchSchema.Version}",
-            $"Composer: {PrefabPatchSchema.ComposerVersion}",
-            $"Discovered manifests: {CurrentMetrics.DiscoveredManifestCount}",
-            $"Resolved plans: {CurrentMetrics.ResolvedPlanCount}",
-            $"Plan cache hits: {CurrentMetrics.CacheHitCount}",
-            $"Plan cache misses: {CurrentMetrics.CacheMissCount}"
+            "Prefab Patches:",
+            $"    Schema: {PrefabPatchSchema.Version}",
+            $"    Composer: {PrefabPatchSchema.ComposerVersion}",
+            $"    Discovered Manifests: {CurrentMetrics.DiscoveredManifestCount}",
+            $"    Resolved Plans: {CurrentMetrics.ResolvedPlanCount}",
+            $"    Plan Cache Hits: {CurrentMetrics.CacheHitCount}",
+            $"    Plan Cache Misses: {CurrentMetrics.CacheMissCount}"
         };
         foreach (
             var pair in Entries.OrderBy(
@@ -689,10 +745,10 @@ public static class PrefabPatchRuntime
         )
         {
             lines.Add("");
-            lines.Add($"Target: {pair.Key}");
-            lines.Add($"Cache key: {pair.Value.Plan.CacheKey}");
+            lines.Add($"    Target - {pair.Key}:");
+            lines.Add($"        Cache Key: {pair.Value.Plan.CacheKey}");
             lines.Add(
-                "Ordered patches: "
+                "        Ordered Patches: "
                     + string.Join(
                         ", ",
                         pair.Value.Plan.OrderedPatchIds
@@ -701,22 +757,27 @@ public static class PrefabPatchRuntime
             foreach (var diagnostic in pair.Value.Plan.Diagnostics)
             {
                 lines.Add(
-                    $"[{diagnostic.Severity}] {diagnostic.Code} "
+                    $"        [{diagnostic.Severity}] {diagnostic.Code} "
                         + $"{diagnostic.PatchId} {diagnostic.OperationId}: "
                         + diagnostic.Message
                 );
             }
 
             if (pair.Value.Failed)
-                lines.Add("Composition failure: " + pair.Value.Failure);
+                lines.Add(
+                    "        Composition Failure: " + pair.Value.Failure
+                );
         }
 
-        File.WriteAllLines(SummaryPath, lines);
+        PatchManagerSummaryLog.UpdatePrefabSummary(
+            string.Join(Environment.NewLine, lines)
+        );
     }
 
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
     private static void ResetStaticState()
     {
+        PatchManagerSummaryLog.Reset();
         ReleaseSessionResources();
         Registered.Clear();
         Entries.Clear();

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -9,6 +9,9 @@ using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.ResourceManagement.ResourceLocations;
 using UnityEngine.ResourceManagement.ResourceProviders;
 using UnityEngine.Profiling;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 using Object = UnityEngine.Object;
 
 namespace PatchManager.PrefabPatching;
@@ -99,6 +102,16 @@ public static class PrefabPatchRuntime
         try
         {
             var manifests = new List<PrefabPatchManifest>(Registered);
+#if UNITY_EDITOR
+            manifests.AddRange(LoadEditorProjectManifests());
+            ResolveDiscoveredManifests(
+                manifests,
+                activeModIds,
+                stopwatch,
+                resolve
+            );
+            return;
+#else
             var locations = FindManifestLocations();
             if (locations.Count > 0)
             {
@@ -166,12 +179,54 @@ public static class PrefabPatchRuntime
                 stopwatch,
                 resolve
             );
+#endif
         }
         catch (Exception exception)
         {
             RejectDiscovery(stopwatch, reject, exception);
         }
     }
+
+#if UNITY_EDITOR
+    private static IEnumerable<PrefabPatchManifest> LoadEditorProjectManifests()
+    {
+        foreach (
+            var path in AssetDatabase
+                .GetAllAssetPaths()
+                .Where(path =>
+                    path.EndsWith(
+                        ".prefabpatch.json",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                .OrderBy(path => path, StringComparer.Ordinal)
+        )
+        {
+            var asset = AssetDatabase.LoadAssetAtPath<TextAsset>(path);
+            if (asset == null)
+                continue;
+
+            PrefabPatchManifest manifest;
+            try
+            {
+                manifest =
+                    PrefabPatchJson.Deserialize<PrefabPatchManifest>(
+                        asset.text
+                    );
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidDataException(
+                    $"Could not parse prefab patch manifest '{path}'.",
+                    exception
+                );
+            }
+
+            if (manifest != null)
+                yield return manifest;
+        }
+    }
+#endif
 
     private static void ResolveDiscoveredManifests(
         IReadOnlyCollection<PrefabPatchManifest> manifests,

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using PatchManager.Core.Assets;
-using PatchManager.Shared;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
@@ -196,7 +194,7 @@ public static class PrefabPatchRuntime
         {
             stopwatch.Stop();
             CurrentMetrics.StartupMilliseconds = stopwatch.ElapsedMilliseconds;
-            Logging.LogError(exception);
+            UnityEngine.Debug.LogException(exception);
             reject(
                 "Patch Manager prefab discovery failed: "
                     + exception.Message
@@ -208,7 +206,8 @@ public static class PrefabPatchRuntime
     /// Adds the public GameObject provider and locator to Patch Manager's
     /// supported KSP AssetProvider interception boundary.
     /// </summary>
-    public static void RegisterResourceProvider()
+    public static UnityEngine.AddressableAssets.ResourceLocators.IResourceLocator
+        RegisterResourceProvider()
     {
         var providers = Addressables.ResourceManager.ResourceProviders;
         if (
@@ -221,7 +220,7 @@ public static class PrefabPatchRuntime
         }
 
         _locator = new PrefabPatchResourceLocator(Entries);
-        Locators.Register(_locator);
+        return _locator;
     }
 
     internal static bool TryProvide(
@@ -339,7 +338,7 @@ public static class PrefabPatchRuntime
             entry.Failed = true;
             entry.Failure = exception;
             failure = exception;
-            Logging.LogError(
+            UnityEngine.Debug.LogError(
                 $"Prefab composition failed for '{address}': {exception}"
             );
             WriteSummary();

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs
@@ -1,0 +1,563 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using PatchManager.Core.Assets;
+using PatchManager.Shared;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceLocations;
+using UnityEngine.ResourceManagement.ResourceProviders;
+using UnityEngine.Profiling;
+using Object = UnityEngine.Object;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Public registry and lazy effective-prefab runtime for the prefab domain.
+/// </summary>
+public static class PrefabPatchRuntime
+{
+    public sealed class Metrics
+    {
+        public int DiscoveredManifestCount;
+        public int ResolvedPlanCount;
+        public int CacheHitCount;
+        public int CacheMissCount;
+        public long StartupMilliseconds;
+        public long FirstCompositionMilliseconds;
+        public long RepeatedRequestMilliseconds;
+        public int RepeatedRequestCount;
+        public long MemoryBeforeBytes;
+        public long MemoryAfterBytes;
+        public int RetainedAddressablesHandles;
+    }
+
+    internal sealed class Entry
+    {
+        public PrefabPatchResolvedPlan Plan;
+        public GameObject EffectivePrefab;
+        public AsyncOperationHandle<GameObject> StockHandle;
+        public List<AsyncOperationHandle<Object>> ReferenceHandles = new();
+        public Dictionary<string, Object> References = new(
+            StringComparer.Ordinal
+        );
+        public bool Failed;
+        public Exception Failure;
+        public int RequestCount;
+    }
+
+    private const string PlanCacheDirectory = "./pm_cache/prefabs";
+    private const string SummaryPath = "./pm_prefab_summary.log";
+    private static readonly List<PrefabPatchManifest> Registered = new();
+    private static readonly Dictionary<string, Entry> Entries = new(
+        StringComparer.Ordinal
+    );
+    private static PrefabPatchResourceLocator _locator;
+
+    public static bool RegistrationOpen { get; private set; } = true;
+    public static Metrics CurrentMetrics { get; private set; } = new();
+    public static IReadOnlyDictionary<string, PrefabPatchResolvedPlan> Plans =>
+        Entries.ToDictionary(pair => pair.Key, pair => pair.Value.Plan);
+
+    /// <summary>
+    /// Registers a fluent or generated C# manifest before registration closes.
+    /// Visual manifests are normally discovered through the public label.
+    /// </summary>
+    public static void Register(PrefabPatchManifest manifest)
+    {
+        if (!RegistrationOpen)
+            throw new InvalidOperationException(
+                "Prefab patch registration is closed for this run."
+            );
+        if (manifest == null)
+            throw new ArgumentNullException(nameof(manifest));
+        Registered.Add(manifest);
+    }
+
+    public static void CloseRegistration()
+    {
+        RegistrationOpen = false;
+    }
+
+    /// <summary>
+    /// Discovers independently built TextAsset manifests, resolves per-prefab
+    /// plans through the atomic cache, and writes a deterministic summary.
+    /// </summary>
+    public static void DiscoverAndResolve(
+        ISet<string> activeModIds,
+        Action resolve,
+        Action<string> reject
+    )
+    {
+        var stopwatch = Stopwatch.StartNew();
+        CurrentMetrics = new Metrics
+        {
+            MemoryBeforeBytes = Profiler.GetTotalAllocatedMemoryLong()
+        };
+        try
+        {
+            var manifests = new List<PrefabPatchManifest>(Registered);
+            var locationsHandle =
+                Addressables.LoadResourceLocationsAsync(
+                    PrefabPatchSchema.AddressablesLabel,
+                    typeof(TextAsset)
+                );
+            var locations = locationsHandle.WaitForCompletion();
+            if (
+                locationsHandle.Status == AsyncOperationStatus.Succeeded
+                && locations != null
+                && locations.Count > 0
+            )
+            {
+                var manifestHandle = Addressables.LoadAssetsAsync<TextAsset>(
+                    locations,
+                    null
+                );
+                var assets = manifestHandle.WaitForCompletion();
+                if (manifestHandle.Status != AsyncOperationStatus.Succeeded)
+                {
+                    throw manifestHandle.OperationException
+                        ?? new InvalidOperationException(
+                            "Prefab patch manifest load failed."
+                        );
+                }
+
+                foreach (var asset in assets.Where(value => value != null))
+                {
+                    try
+                    {
+                        manifests.Add(
+                            PrefabPatchJson.Deserialize<PrefabPatchManifest>(
+                                asset.text
+                            )
+                        );
+                    }
+                    catch (Exception exception)
+                    {
+                        throw new InvalidDataException(
+                            $"Could not parse prefab patch manifest "
+                                + $"'{asset.name}'.",
+                            exception
+                        );
+                    }
+                }
+
+                Addressables.Release(manifestHandle);
+            }
+
+            Addressables.Release(locationsHandle);
+            CurrentMetrics.DiscoveredManifestCount = manifests.Count;
+            var cache = new PrefabPatchPlanCache(PlanCacheDirectory);
+            Entries.Clear();
+            foreach (
+                var group in manifests
+                    .Where(value => value?.TargetPrefab != null)
+                    .GroupBy(
+                        value => value.TargetPrefab.CanonicalKey,
+                        StringComparer.Ordinal
+                    )
+                    .OrderBy(group => group.Key, StringComparer.Ordinal)
+            )
+            {
+                var result = cache.LoadOrResolve(
+                    group,
+                    activeModIds,
+                    Application.unityVersion,
+                    Application.platform.ToString()
+                );
+                if (result.CacheHit)
+                    CurrentMetrics.CacheHitCount++;
+                else
+                    CurrentMetrics.CacheMissCount++;
+                if (
+                    result.Plan?.TargetPrefab != null
+                    && result.Plan.IsValid
+                )
+                {
+                    Entries[result.Plan.TargetPrefab.Address] = new Entry
+                    {
+                        Plan = result.Plan
+                    };
+                }
+            }
+
+            CurrentMetrics.ResolvedPlanCount = Entries.Count;
+            WriteSummary();
+            stopwatch.Stop();
+            CurrentMetrics.StartupMilliseconds = stopwatch.ElapsedMilliseconds;
+            CurrentMetrics.MemoryAfterBytes =
+                Profiler.GetTotalAllocatedMemoryLong();
+            resolve();
+        }
+        catch (Exception exception)
+        {
+            stopwatch.Stop();
+            CurrentMetrics.StartupMilliseconds = stopwatch.ElapsedMilliseconds;
+            Logging.LogError(exception);
+            reject(
+                "Patch Manager prefab discovery failed: "
+                    + exception.Message
+            );
+        }
+    }
+
+    /// <summary>
+    /// Adds the public GameObject provider and locator to Patch Manager's
+    /// supported KSP AssetProvider interception boundary.
+    /// </summary>
+    public static void RegisterResourceProvider()
+    {
+        var providers = Addressables.ResourceManager.ResourceProviders;
+        if (
+            !providers.Any(
+                provider => provider is PrefabPatchResourceProvider
+            )
+        )
+        {
+            providers.Add(new PrefabPatchResourceProvider());
+        }
+
+        _locator = new PrefabPatchResourceLocator(Entries);
+        Locators.Register(_locator);
+    }
+
+    internal static bool TryProvide(
+        string address,
+        out GameObject prefab,
+        out Exception failure
+    )
+    {
+        prefab = null;
+        failure = null;
+        if (!Entries.TryGetValue(address, out var entry))
+        {
+            failure = new KeyNotFoundException(
+                $"No resolved prefab patch plan exists for '{address}'."
+            );
+            return false;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        entry.RequestCount++;
+        if (entry.EffectivePrefab != null)
+        {
+            stopwatch.Stop();
+            CurrentMetrics.RepeatedRequestCount++;
+            CurrentMetrics.RepeatedRequestMilliseconds +=
+                stopwatch.ElapsedMilliseconds;
+            prefab = entry.EffectivePrefab;
+            return true;
+        }
+
+        if (entry.Failed)
+        {
+            failure = entry.Failure;
+            return false;
+        }
+
+        try
+        {
+            var stockLocation = ResolveOriginalLocation(
+                address,
+                typeof(GameObject)
+            );
+            entry.StockHandle =
+                Addressables.LoadAssetAsync<GameObject>(stockLocation);
+            var stock = entry.StockHandle.WaitForCompletion();
+            if (
+                entry.StockHandle.Status != AsyncOperationStatus.Succeeded
+                || stock == null
+            )
+            {
+                throw entry.StockHandle.OperationException
+                    ?? new InvalidOperationException(
+                        $"Could not load stock prefab '{address}'."
+                    );
+            }
+
+            foreach (
+                var reference in entry.Plan.Operations
+                    .SelectMany(GetReferences)
+                    .Where(value => value != null)
+                    .GroupBy(value => value.Address, StringComparer.Ordinal)
+                    .Select(group => group.First())
+                    .OrderBy(value => value.Address, StringComparer.Ordinal)
+            )
+            {
+                var location = ResolveOriginalLocation(
+                    reference.Address,
+                    typeof(Object)
+                );
+                var handle = Addressables.LoadAssetAsync<Object>(location);
+                var value = handle.WaitForCompletion();
+                if (
+                    handle.Status != AsyncOperationStatus.Succeeded
+                    || value == null
+                )
+                {
+                    throw handle.OperationException
+                        ?? new InvalidOperationException(
+                            $"Could not load prefab patch reference "
+                                + $"'{reference.Address}'."
+                        );
+                }
+
+                entry.ReferenceHandles.Add(handle);
+                entry.References.Add(reference.Address, value);
+            }
+
+            var result = PrefabPatchComposer.ApplySynchronously(
+                stock,
+                entry.Plan,
+                entry.References
+            );
+            if (!result.Success)
+                throw new InvalidOperationException(result.Failure);
+            entry.EffectivePrefab = stock;
+            stopwatch.Stop();
+            CurrentMetrics.FirstCompositionMilliseconds +=
+                stopwatch.ElapsedMilliseconds;
+            CurrentMetrics.RetainedAddressablesHandles =
+                Entries.Values.Sum(
+                    value =>
+                        (value.StockHandle.IsValid() ? 1 : 0)
+                        + value.ReferenceHandles.Count(
+                            handle => handle.IsValid()
+                        )
+                );
+            CurrentMetrics.MemoryAfterBytes =
+                Profiler.GetTotalAllocatedMemoryLong();
+            prefab = stock;
+            return true;
+        }
+        catch (Exception exception)
+        {
+            stopwatch.Stop();
+            entry.Failed = true;
+            entry.Failure = exception;
+            failure = exception;
+            Logging.LogError(
+                $"Prefab composition failed for '{address}': {exception}"
+            );
+            WriteSummary();
+            return false;
+        }
+    }
+
+    private static IResourceLocation ResolveOriginalLocation(
+        string address,
+        Type type
+    )
+    {
+        var handle =
+            type == typeof(Object)
+                ? Addressables.LoadResourceLocationsAsync(address)
+                : Addressables.LoadResourceLocationsAsync(address, type);
+        var locations = handle.WaitForCompletion();
+        try
+        {
+            if (
+                handle.Status != AsyncOperationStatus.Succeeded
+                || locations == null
+                || locations.Count == 0
+            )
+            {
+                throw handle.OperationException
+                    ?? new InvalidOperationException(
+                        $"No original Addressables location exists for "
+                            + $"'{address}' as '{type.FullName}'."
+                    );
+            }
+
+            return locations
+                .Where(
+                    location =>
+                        !string.Equals(
+                            location.ProviderId,
+                            typeof(PrefabPatchResourceProvider).FullName,
+                            StringComparison.Ordinal
+                        )
+                )
+                .OrderBy(location => location.PrimaryKey, StringComparer.Ordinal)
+                .ThenBy(location => location.InternalId, StringComparer.Ordinal)
+                .FirstOrDefault()
+                ?? throw new InvalidOperationException(
+                    $"Only recursive prefab-patch locations exist for "
+                        + $"'{address}'."
+                );
+        }
+        finally
+        {
+            Addressables.Release(handle);
+        }
+    }
+
+    private static IEnumerable<PrefabPatchObjectReference> GetReferences(
+        PrefabPatchOperation operation
+    )
+    {
+        if (operation.ObjectReference != null)
+            yield return operation.ObjectReference;
+        if (operation.AddedComponent?.Mesh != null)
+            yield return operation.AddedComponent.Mesh;
+        if (operation.AddedObject == null)
+            yield break;
+        foreach (var reference in GetReferences(operation.AddedObject))
+            yield return reference;
+    }
+
+    private static IEnumerable<PrefabPatchObjectReference> GetReferences(
+        PrefabPatchObjectFragment fragment
+    )
+    {
+        foreach (var component in fragment.Components)
+        {
+            if (component.Mesh != null)
+                yield return component.Mesh;
+        }
+
+        foreach (var child in fragment.Children)
+        {
+            foreach (var reference in GetReferences(child))
+                yield return reference;
+        }
+    }
+
+    private static void WriteSummary()
+    {
+        var lines = new List<string>
+        {
+            "Patch Manager prefab patch summary",
+            $"Schema: {PrefabPatchSchema.Version}",
+            $"Composer: {PrefabPatchSchema.ComposerVersion}",
+            $"Discovered manifests: {CurrentMetrics.DiscoveredManifestCount}",
+            $"Resolved plans: {CurrentMetrics.ResolvedPlanCount}",
+            $"Plan cache hits: {CurrentMetrics.CacheHitCount}",
+            $"Plan cache misses: {CurrentMetrics.CacheMissCount}"
+        };
+        foreach (
+            var pair in Entries.OrderBy(
+                value => value.Key,
+                StringComparer.Ordinal
+            )
+        )
+        {
+            lines.Add("");
+            lines.Add($"Target: {pair.Key}");
+            lines.Add($"Cache key: {pair.Value.Plan.CacheKey}");
+            lines.Add(
+                "Ordered patches: "
+                    + string.Join(
+                        ", ",
+                        pair.Value.Plan.OrderedPatchIds
+                    )
+            );
+            foreach (var diagnostic in pair.Value.Plan.Diagnostics)
+            {
+                lines.Add(
+                    $"[{diagnostic.Severity}] {diagnostic.Code} "
+                        + $"{diagnostic.PatchId} {diagnostic.OperationId}: "
+                        + diagnostic.Message
+                );
+            }
+
+            if (pair.Value.Failed)
+                lines.Add("Composition failure: " + pair.Value.Failure);
+        }
+
+        File.WriteAllLines(SummaryPath, lines);
+    }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    private static void ResetStaticState()
+    {
+        Registered.Clear();
+        Entries.Clear();
+        _locator = null;
+        RegistrationOpen = true;
+        CurrentMetrics = new Metrics();
+    }
+}
+
+internal sealed class PrefabPatchResourceLocator :
+    UnityEngine.AddressableAssets.ResourceLocators.IResourceLocator
+{
+    private readonly IReadOnlyDictionary<string, PrefabPatchRuntime.Entry> _entries;
+
+    public PrefabPatchResourceLocator(
+        IReadOnlyDictionary<string, PrefabPatchRuntime.Entry> entries
+    )
+    {
+        _entries = entries;
+    }
+
+    public string LocatorId => GetType().FullName;
+    public IEnumerable<object> Keys => _entries.Keys;
+
+    public bool Locate(
+        object key,
+        Type type,
+        out IList<IResourceLocation> locations
+    )
+    {
+        var address = key?.ToString();
+        if (
+            string.IsNullOrWhiteSpace(address)
+            || !_entries.ContainsKey(address)
+            || (
+                type != typeof(object)
+                && type != typeof(Object)
+                && type != typeof(GameObject)
+                && !typeof(Component).IsAssignableFrom(type)
+            )
+        )
+        {
+            locations = Array.Empty<IResourceLocation>();
+            return false;
+        }
+
+        locations = new IResourceLocation[]
+        {
+            new ResourceLocationBase(
+                "prefab-patch:" + address,
+                address,
+                typeof(PrefabPatchResourceProvider).FullName,
+                typeof(GameObject)
+            )
+        };
+        return true;
+    }
+}
+
+internal sealed class PrefabPatchResourceProvider : ResourceProviderBase
+{
+    public override void Provide(ProvideHandle provideHandle)
+    {
+        if (
+            PrefabPatchRuntime.TryProvide(
+                provideHandle.Location.InternalId,
+                out var prefab,
+                out var failure
+            )
+        )
+        {
+            provideHandle.Complete(prefab, true, null);
+        }
+        else
+        {
+            provideHandle.Complete<GameObject>(null, false, failure);
+        }
+    }
+
+    public override Type GetDefaultType(IResourceLocation location) =>
+        typeof(GameObject);
+
+    public override void Release(IResourceLocation location, object obj)
+    {
+        // Effective prefabs and their stock/mod Addressables handles are retained
+        // for the game session. They are cleared by SubsystemRegistration.
+    }
+}

--- a/Runtime/PrefabPatching/PrefabPatchRuntime.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchRuntime.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c3c89da17222224780397bedec236ed

--- a/Runtime/PrefabPatching/PrefabPatchStructure.cs
+++ b/Runtime/PrefabPatching/PrefabPatchStructure.cs
@@ -60,6 +60,57 @@ public static class PrefabPatchStructure
         return current;
     }
 
+    public static Transform ResolveHierarchyPath(
+        Transform root,
+        string hierarchyPath
+    )
+    {
+        if (root == null)
+            return null;
+        var parts = (hierarchyPath ?? string.Empty)
+            .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        var index = 0;
+        if (
+            parts.Length > 0
+            && string.Equals(
+                parts[0],
+                root.name,
+                StringComparison.Ordinal
+            )
+        )
+        {
+            index = 1;
+        }
+
+        var current = root;
+        for (; index < parts.Length; index++)
+        {
+            var name = parts[index];
+            Transform match = null;
+            for (var childIndex = 0; childIndex < current.childCount; childIndex++)
+            {
+                var child = current.GetChild(childIndex);
+                if (!string.Equals(child.name, name, StringComparison.Ordinal))
+                    continue;
+                if (match != null)
+                {
+                    throw new InvalidOperationException(
+                        $"Hierarchy path '{hierarchyPath}' is ambiguous: "
+                            + $"'{current.name}' has multiple children named "
+                            + $"'{name}'. Use visual authoring for this target."
+                    );
+                }
+                match = child;
+            }
+
+            if (match == null)
+                return null;
+            current = match;
+        }
+
+        return current;
+    }
+
     private static void Append(
         Transform transform,
         StringBuilder builder,

--- a/Runtime/PrefabPatching/PrefabPatchStructure.cs
+++ b/Runtime/PrefabPatching/PrefabPatchStructure.cs
@@ -14,11 +14,19 @@ public static class PrefabPatchStructure
 {
     public static string Calculate(GameObject root)
     {
+        var description = Describe(root);
+        return description == null
+            ? null
+            : PrefabPatchJson.Sha256(description);
+    }
+
+    public static string Describe(GameObject root)
+    {
         if (root == null)
             return null;
         var builder = new StringBuilder();
         Append(root.transform, builder);
-        return PrefabPatchJson.Sha256(builder.ToString());
+        return builder.ToString();
     }
 
     public static int[] GetSiblingPath(Transform root, Transform target)
@@ -57,7 +65,7 @@ public static class PrefabPatchStructure
         builder.Append('[')
             .Append(transform.GetSiblingIndex())
             .Append('|')
-            .Append(transform.name)
+            .Append(transform.parent == null ? "<root>" : transform.name)
             .Append('|')
             .Append(transform.gameObject.activeSelf ? '1' : '0');
         foreach (
@@ -67,7 +75,7 @@ public static class PrefabPatchStructure
         )
         {
             builder.Append('|')
-                .Append(component.GetType().AssemblyQualifiedName);
+                .Append(component.GetType().FullName);
         }
 
         builder.Append(']');

--- a/Runtime/PrefabPatching/PrefabPatchStructure.cs
+++ b/Runtime/PrefabPatching/PrefabPatchStructure.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace PatchManager.PrefabPatching;
+
+/// <summary>
+/// Runtime-computable hierarchy fingerprint and sibling-index traversal.
+/// Canonical identity still comes from BundleKit CAB/path IDs.
+/// </summary>
+public static class PrefabPatchStructure
+{
+    public static string Calculate(GameObject root)
+    {
+        if (root == null)
+            return null;
+        var builder = new StringBuilder();
+        Append(root.transform, builder);
+        return PrefabPatchJson.Sha256(builder.ToString());
+    }
+
+    public static int[] GetSiblingPath(Transform root, Transform target)
+    {
+        var reverse = new List<int>();
+        var current = target;
+        while (current != null && current != root)
+        {
+            reverse.Add(current.GetSiblingIndex());
+            current = current.parent;
+        }
+
+        if (current != root)
+            throw new InvalidOperationException(
+                $"Transform '{target?.name}' is not beneath '{root?.name}'."
+            );
+        reverse.Reverse();
+        return reverse.ToArray();
+    }
+
+    public static Transform Resolve(Transform root, IEnumerable<int> path)
+    {
+        var current = root;
+        foreach (var index in path ?? Array.Empty<int>())
+        {
+            if (index < 0 || index >= current.childCount)
+                return null;
+            current = current.GetChild(index);
+        }
+
+        return current;
+    }
+
+    private static void Append(Transform transform, StringBuilder builder)
+    {
+        builder.Append('[')
+            .Append(transform.GetSiblingIndex())
+            .Append('|')
+            .Append(transform.name)
+            .Append('|')
+            .Append(transform.gameObject.activeSelf ? '1' : '0');
+        foreach (
+            var component in transform.gameObject
+                .GetComponents<Component>()
+                .Where(value => value != null)
+        )
+        {
+            builder.Append('|')
+                .Append(component.GetType().AssemblyQualifiedName);
+        }
+
+        builder.Append(']');
+        for (var i = 0; i < transform.childCount; i++)
+            Append(transform.GetChild(i), builder);
+    }
+}

--- a/Runtime/PrefabPatching/PrefabPatchStructure.cs
+++ b/Runtime/PrefabPatching/PrefabPatchStructure.cs
@@ -25,7 +25,7 @@ public static class PrefabPatchStructure
         if (root == null)
             return null;
         var builder = new StringBuilder();
-        Append(root.transform, builder);
+        Append(root.transform, builder, true);
         return builder.ToString();
     }
 
@@ -60,12 +60,16 @@ public static class PrefabPatchStructure
         return current;
     }
 
-    private static void Append(Transform transform, StringBuilder builder)
+    private static void Append(
+        Transform transform,
+        StringBuilder builder,
+        bool isRoot
+    )
     {
         builder.Append('[')
-            .Append(transform.GetSiblingIndex())
+            .Append(isRoot ? 0 : transform.GetSiblingIndex())
             .Append('|')
-            .Append(transform.parent == null ? "<root>" : transform.name)
+            .Append(isRoot ? "<root>" : transform.name)
             .Append('|')
             .Append(transform.gameObject.activeSelf ? '1' : '0');
         foreach (
@@ -80,6 +84,6 @@ public static class PrefabPatchStructure
 
         builder.Append(']');
         for (var i = 0; i < transform.childCount; i++)
-            Append(transform.GetChild(i), builder);
+            Append(transform.GetChild(i), builder, false);
     }
 }

--- a/Runtime/PrefabPatching/PrefabPatchStructure.cs.meta
+++ b/Runtime/PrefabPatching/PrefabPatchStructure.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc85d159dc8e85540bde3db0e49075e8

--- a/Stubs/pm-prefabs.d.lua
+++ b/Stubs/pm-prefabs.d.lua
@@ -112,6 +112,22 @@ function PrefabPatchLuaBuilder:Configuration(...) end
 ---@return PrefabPatchLuaBuilder self
 function PrefabPatchLuaBuilder:Set(operationId, target, propertyPath, value) end
 ---@param operationId string
+---@param hierarchyPath string Slash-separated path; the root name is optional.
+---@param componentType string Full CLR type name, for example UnityEngine.UI.Image.
+---@param propertyPath string
+---@param value boolean|number|string|PrefabPatchValue
+---@param componentOrdinal? integer Zero-based ordinal when the GameObject has multiple components of this type.
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:SetComponent(operationId, hierarchyPath, componentType, propertyPath, value, componentOrdinal) end
+---@param hierarchyPath string Slash-separated path; the root name is optional.
+---@return PrefabPatchTarget target
+function PrefabPatchLuaBuilder:GameObject(hierarchyPath) end
+---@param hierarchyPath string Slash-separated path; the root name is optional.
+---@param componentType string Full CLR type name.
+---@param componentOrdinal? integer Zero-based ordinal when the GameObject has multiple components of this type.
+---@return PrefabPatchTarget target
+function PrefabPatchLuaBuilder:Component(hierarchyPath, componentType, componentOrdinal) end
+---@param operationId string
 ---@param target PrefabPatchTarget
 ---@param propertyPath string
 ---@param reference PrefabPatchReference
@@ -146,6 +162,6 @@ function PrefabPatchLuaBuilder:Build() end
 function PrefabPatchLuaBuilder:Register() end
 
 ---@param name string Patch-local name; ModId is prepended automatically.
----@param target PrefabPatchIdentity
+---@param target string|PrefabPatchIdentity Addressables key for handwritten patches; full identity tables are generated-tool input.
 ---@return PrefabPatchLuaBuilder builder
 function PatchManagerCore:Prefab(name, target) end

--- a/Stubs/pm-prefabs.d.lua
+++ b/Stubs/pm-prefabs.d.lua
@@ -2,7 +2,7 @@
 -- Patch Manager declarative prefab-patch frontend.
 
 ---@alias PrefabPatchTarget table
----| { kind: '"Stock"', sourceSerializedFileName: string, sourcePathId: integer|string, objectType: string, runtimeLocator: table }
+---| { kind: '"Stock"', objectType: string, runtimeLocator: table }
 ---| { kind: '"PatchOwned"', ownerPatchId: string, objectId: string, objectType: string?, runtimeLocator: table? }
 ---| { kind: '"PatchComponent"', ownerPatchId: string, componentId: string, objectType: string? }
 
@@ -54,18 +54,6 @@
 ---@field pivot PrefabPatchValue?
 ---@field components PrefabPatchComponentFragment[]?
 ---@field children PrefabPatchObjectFragment[]?
-
----@class PrefabPatchIdentity
----@field address string
----@field catalogId string
----@field catalogHash string?
----@field sourceBundleFileName string
----@field sourceBundleHash string?
----@field sourceSerializedFileName string
----@field sourcePathId integer|string Use a decimal string for 64-bit IDs outside Lua's exact numeric range.
----@field assetType string
----@field structuralDescription string
----@field structuralFingerprint string
 
 ---@class PrefabPatchLuaBuilder
 PrefabPatchLuaBuilder = {}
@@ -162,6 +150,6 @@ function PrefabPatchLuaBuilder:Build() end
 function PrefabPatchLuaBuilder:Register() end
 
 ---@param name string Patch-local name; ModId is prepended automatically.
----@param target string|PrefabPatchIdentity Addressables key for handwritten patches; full identity tables are generated-tool input.
+---@param target string Stock prefab Addressables key.
 ---@return PrefabPatchLuaBuilder builder
 function PatchManagerCore:Prefab(name, target) end

--- a/Stubs/pm-prefabs.d.lua
+++ b/Stubs/pm-prefabs.d.lua
@@ -1,155 +1,305 @@
 ---@meta
 -- Patch Manager declarative prefab-patch frontend.
+-- Source: ksp2redux/Assets/Modules/PatchManager/Runtime/LuaPatching/Builtin/PatchManagerCore.cs
+-- Source: ksp2redux/Assets/Modules/PatchManager/Runtime/LuaPatching/Builtin/PrefabPatchLuaBuilder.cs
+-- Source: ksp2redux/Assets/Modules/PatchManager/Runtime/PrefabPatching/PrefabPatchBuilder.cs
+-- Source: ksp2redux/Assets/Modules/PatchManager/Runtime/PrefabPatching/PrefabPatchModel.cs
 
----@alias PrefabPatchTarget table
----| { kind: '"Stock"', objectType: string, runtimeLocator: table }
----| { kind: '"PatchOwned"', ownerPatchId: string, objectId: string, objectType: string?, runtimeLocator: table? }
----| { kind: '"PatchComponent"', ownerPatchId: string, componentId: string, objectType: string? }
+---Describes how Patch Manager locates a GameObject or Component in the stock
+---prefab. Key-first Lua authoring normally uses `hierarchyPath`; manifests
+---compiled from visual prefab variants may use `siblingIndices` instead.
+---@class PrefabPatchRuntimeLocator
+---@field siblingIndices integer[]? Zero-based sibling indices from the prefab root to the target.
+---@field hierarchyPath string? Slash-separated hierarchy path; the root name is optional.
+---@field targetKind '"GameObject"'|'"Component"' Whether the locator resolves a GameObject or one of its Components.
+---@field componentType string? Full CLR component type name when `targetKind` is `"Component"`.
+---@field componentOrdinal integer? Zero-based ordinal when a GameObject has multiple Components of the same type.
+---@field displayPath string? Human-readable path used in diagnostics.
 
----@alias PrefabPatchReference table
----| { kind: '"Addressable"', address: string, expectedType: string? }
----| { kind: '"Target"', target: PrefabPatchTarget, expectedType: string? }
+---Targets an object or Component inherited from the stock prefab.
+---@class PrefabPatchStockTarget
+---@field kind '"Stock"'
+---@field objectType string Full CLR type name expected at the resolved location.
+---@field runtimeLocator PrefabPatchRuntimeLocator Runtime traversal information for the stock prefab.
 
+---Targets a GameObject introduced by this patch or by another named patch.
+---Use an unqualified `ownerPatchId` for a patch in the current mod; Patch
+---Manager adds the current mod ID when the manifest is registered.
+---@class PrefabPatchOwnedTarget
+---@field kind '"PatchOwned"'
+---@field ownerPatchId string Owning patch ID, either a local patch name or a fully qualified `modId:patchName`.
+---@field objectId string Stable object ID declared by the owning patch's `PrefabPatchObjectFragment`.
+---@field objectType string? Expected CLR object type; normally `UnityEngine.GameObject`.
+---@field runtimeLocator PrefabPatchRuntimeLocator? Optional diagnostic locator; patch-owned identity is based on IDs.
+
+---Targets a Component introduced by this patch or by another named patch.
+---Use an unqualified `ownerPatchId` for a patch in the current mod.
+---@class PrefabPatchOwnedComponentTarget
+---@field kind '"PatchComponent"'
+---@field ownerPatchId string Owning patch ID, either a local patch name or a fully qualified `modId:patchName`.
+---@field componentId string Stable component ID declared by the owning patch's `PrefabPatchComponentFragment`.
+---@field objectType string? Expected full CLR component type name.
+
+---A stock target, a patch-owned GameObject, or a patch-owned Component.
+---@alias PrefabPatchTarget
+---| PrefabPatchStockTarget
+---| PrefabPatchOwnedTarget
+---| PrefabPatchOwnedComponentTarget
+
+---References an asset loaded through Addressables.
+---@class PrefabPatchAddressableReference
+---@field kind '"Addressable"'
+---@field address string Addressables key of the referenced Unity object.
+---@field expectedType string? Full CLR type name used to validate the loaded object.
+
+---References another object represented by a prefab-patch target.
+---@class PrefabPatchTargetReference
+---@field kind '"Target"'
+---@field target PrefabPatchTarget Target whose resolved Unity object should be assigned.
+---@field expectedType string? Full CLR type name used to validate the resolved object.
+
+---A Unity object reference assigned by a prefab-patch operation.
+---@alias PrefabPatchReference
+---| PrefabPatchAddressableReference
+---| PrefabPatchTargetReference
+
+---The serialized value kinds accepted by the prefab-patch composer.
+---@alias PrefabPatchValueKind
+---| '"Boolean"'
+---| '"Integer"'
+---| '"Float"'
+---| '"String"'
+---| '"Vector2"'
+---| '"Vector3"'
+---| '"Vector4"'
+---| '"Quaternion"'
+---| '"Color"'
+---| '"ArraySize"'
+---| '"ManagedReference"'
+---| '"Json"'
+
+---A JSON-safe typed value for a Unity serialized property. Only the payload
+---fields required by `kind` need to be supplied. Plain Lua booleans, numbers,
+---and strings can be passed to `Set`; use this class for vectors, colors,
+---integers, array sizes, managed references, or explicit JSON payloads.
 ---@class PrefabPatchValue
----@field kind '"Boolean"'|'"Integer"'|'"Float"'|'"String"'|'"Vector2"'|'"Vector3"'|'"Vector4"'|'"Quaternion"'|'"Color"'|'"ArraySize"'|'"ManagedReference"'|'"Json"'
----@field boolean boolean?
----@field integer integer?
----@field float number?
----@field string string?
----@field serializedType string?
----@field x number?
----@field y number?
----@field z number?
----@field w number?
+---@field kind PrefabPatchValueKind Selects which payload fields Patch Manager reads.
+---@field boolean boolean? Payload for `"Boolean"`.
+---@field integer integer? Payload for `"Integer"` and `"ArraySize"`.
+---@field float number? Payload for `"Float"`.
+---@field string string? Payload for `"String"` or serialized `"Json"`.
+---@field serializedType string? Assembly-qualified concrete type for `"ManagedReference"`.
+---@field x number? X or red component for vector, quaternion, and color values.
+---@field y number? Y or green component for vector, quaternion, and color values.
+---@field z number? Z or blue component for Vector3, Vector4, Quaternion, and Color values.
+---@field w number? W or alpha component for Vector4, Quaternion, and Color values.
 
+---One non-object serialized property captured for a patch-owned Component.
 ---@class PrefabPatchSerializedValue
----@field propertyPath string
----@field value PrefabPatchValue
+---@field propertyPath string Unity `SerializedProperty` path relative to the Component.
+---@field value PrefabPatchValue Typed value written to the property.
 
+---One Unity object reference captured separately from a Component's scalar
+---serialized values so it can be restored after all patch-owned objects exist.
 ---@class PrefabPatchSerializedReference
----@field propertyPath string
----@field reference PrefabPatchReference
+---@field propertyPath string Unity `SerializedProperty` path relative to the Component.
+---@field reference PrefabPatchReference Object reference written to the property.
 
+---Serialized definition of a Component introduced by a prefab patch.
 ---@class PrefabPatchComponentFragment
----@field componentId string Stable ID unique within the patch.
----@field componentType string Assembly-qualified CLR component type.
----@field values PrefabPatchSerializedValue[]?
----@field references PrefabPatchSerializedReference[]?
+---@field componentId string Stable ID unique within the owning patch and usable by later patches.
+---@field componentType string Assembly-qualified CLR component type to add.
+---@field values PrefabPatchSerializedValue[]? Non-object serialized properties to initialize.
+---@field references PrefabPatchSerializedReference[]? Unity object references restored after object creation.
 
+---Inline hierarchy definition for a GameObject introduced by a prefab patch.
+---Every object has a stable `objectId`, allowing dependent patches to target it
+---without relying on its display name or hierarchy position.
 ---@class PrefabPatchObjectFragment
----@field objectId string Stable ID unique within the patch.
----@field name string?
----@field transformType string? Assembly-qualified Transform or RectTransform type.
----@field active boolean?
----@field layer integer?
----@field tag string?
----@field isStatic boolean?
----@field localPosition PrefabPatchValue?
----@field localRotation PrefabPatchValue?
----@field localScale PrefabPatchValue?
----@field anchorMin PrefabPatchValue?
----@field anchorMax PrefabPatchValue?
----@field anchoredPosition PrefabPatchValue?
----@field sizeDelta PrefabPatchValue?
----@field pivot PrefabPatchValue?
----@field components PrefabPatchComponentFragment[]?
----@field children PrefabPatchObjectFragment[]?
+---@field objectId string Stable ID unique within the owning patch.
+---@field name string? GameObject name; defaults to the object ID when omitted.
+---@field transformType string? Assembly-qualified Transform type; use RectTransform for UI objects.
+---@field active boolean? Initial active state; defaults to true.
+---@field layer integer? Initial Unity layer.
+---@field tag string? Initial Unity tag; defaults to `Untagged`.
+---@field isStatic boolean? Initial `GameObject.isStatic` value.
+---@field localPosition PrefabPatchValue? Local Transform position.
+---@field localRotation PrefabPatchValue? Local Transform rotation.
+---@field localScale PrefabPatchValue? Local Transform scale.
+---@field anchorMin PrefabPatchValue? RectTransform minimum anchor.
+---@field anchorMax PrefabPatchValue? RectTransform maximum anchor.
+---@field anchoredPosition PrefabPatchValue? RectTransform anchored position.
+---@field sizeDelta PrefabPatchValue? RectTransform size delta.
+---@field pivot PrefabPatchValue? RectTransform pivot.
+---@field components PrefabPatchComponentFragment[]? Components introduced on this GameObject.
+---@field children PrefabPatchObjectFragment[]? Nested patch-owned child GameObjects.
 
+---Fluent Lua frontend for one declarative prefab patch. Builder methods mutate
+---the pending manifest and return the same builder unless documented otherwise.
 ---@class PrefabPatchLuaBuilder
 PrefabPatchLuaBuilder = {}
 
----@return PrefabPatchLuaBuilder self
+---Places the patch in the Early pass.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Early() end
----@return PrefabPatchLuaBuilder self
+
+---Places the patch in the Late pass.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Late() end
----@return PrefabPatchLuaBuilder self
+
+---Places the patch in the First ordering bucket within its pass.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:First() end
----@return PrefabPatchLuaBuilder self
+
+---Places the patch in the Last ordering bucket within its pass.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Last() end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Requires all listed mods. Patch Manager skips this patch when a required mod
+---is unavailable.
+---@param ... string The required mod IDs.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Needs(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Declares this patch incompatible with the listed mods.
+---@param ... string The conflicting mod IDs.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Conflicts(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Requires all listed prefab patches. Local names are qualified with the
+---current mod ID; use `modId:patchName` to reference another mod's patch.
+---@param ... string Required local names or fully qualified patch IDs.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:NeedsPatch(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Declares this patch incompatible with the listed prefab patches. Local names
+---are qualified with the current mod ID.
+---@param ... string Conflicting local names or fully qualified patch IDs.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:ConflictsPatch(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Orders this patch before the listed patches when they are present.
+---@param ... string Local names or fully qualified patch IDs to run before.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:BeforePatch(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Orders this patch after the listed patches when they are present.
+---@param ... string Local names or fully qualified patch IDs to run after.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:AfterPatch(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Orders this patch before every present prefab patch owned by the listed mods.
+---@param ... string Mod IDs whose patches should run later.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Before(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Orders this patch after every present prefab patch owned by the listed mods.
+---@param ... string Mod IDs whose patches should run earlier.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:After(...) end
----@param ... string
----@return PrefabPatchLuaBuilder self
+
+---Declares configuration identifiers that affect the patch, making them part
+---of the resolved-plan cache input.
+---@param ... string Stable configuration identifiers used by this patch.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Configuration(...) end
----@param operationId string
----@param target PrefabPatchTarget
----@param propertyPath string
----@param value boolean|number|string|PrefabPatchValue
----@return PrefabPatchLuaBuilder self
+
+---Adds a typed serialized-property assignment to any prefab-patch target.
+---Plain Lua numbers are emitted as `"Float"` values; use `PrefabPatchValue`
+---when an integer or another explicit value kind is required.
+---@param operationId string Stable operation ID unique within this patch.
+---@param target PrefabPatchTarget Object or Component whose property should change.
+---@param propertyPath string Unity `SerializedProperty` path to write.
+---@param value boolean|number|string|PrefabPatchValue Value to serialize.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Set(operationId, target, propertyPath, value) end
----@param operationId string
+
+---Convenience form of `Set` for a Component inherited from the stock prefab.
+---@param operationId string Stable operation ID unique within this patch.
+---@param hierarchyPath string Slash-separated GameObject path; the root name is optional.
+---@param componentType string Full CLR component type name, for example `UnityEngine.UI.Image`.
+---@param propertyPath string Unity `SerializedProperty` path to write.
+---@param value boolean|number|string|PrefabPatchValue Value to serialize.
+---@param componentOrdinal? integer Zero-based ordinal when the GameObject has multiple Components of this type.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
+function PrefabPatchLuaBuilder:SetComponent(
+    operationId,
+    hierarchyPath,
+    componentType,
+    propertyPath,
+    value,
+    componentOrdinal
+)
+end
+
+---Creates a target for a GameObject inherited from the stock prefab.
 ---@param hierarchyPath string Slash-separated path; the root name is optional.
----@param componentType string Full CLR type name, for example UnityEngine.UI.Image.
----@param propertyPath string
----@param value boolean|number|string|PrefabPatchValue
----@param componentOrdinal? integer Zero-based ordinal when the GameObject has multiple components of this type.
----@return PrefabPatchLuaBuilder self
-function PrefabPatchLuaBuilder:SetComponent(operationId, hierarchyPath, componentType, propertyPath, value, componentOrdinal) end
----@param hierarchyPath string Slash-separated path; the root name is optional.
----@return PrefabPatchTarget target
+---@return PrefabPatchStockTarget target A reusable stock GameObject target.
 function PrefabPatchLuaBuilder:GameObject(hierarchyPath) end
----@param hierarchyPath string Slash-separated path; the root name is optional.
----@param componentType string Full CLR type name.
----@param componentOrdinal? integer Zero-based ordinal when the GameObject has multiple components of this type.
----@return PrefabPatchTarget target
+
+---Creates a target for a Component inherited from the stock prefab.
+---@param hierarchyPath string Slash-separated GameObject path; the root name is optional.
+---@param componentType string Full CLR component type name.
+---@param componentOrdinal? integer Zero-based ordinal when the GameObject has multiple Components of this type.
+---@return PrefabPatchStockTarget target A reusable stock Component target.
 function PrefabPatchLuaBuilder:Component(hierarchyPath, componentType, componentOrdinal) end
----@param operationId string
----@param target PrefabPatchTarget
----@param propertyPath string
----@param reference PrefabPatchReference
----@return PrefabPatchLuaBuilder self
+
+---Adds a Unity object-reference assignment to a serialized property.
+---@param operationId string Stable operation ID unique within this patch.
+---@param target PrefabPatchTarget Object or Component whose property should change.
+---@param propertyPath string Unity `SerializedProperty` path to write.
+---@param reference PrefabPatchReference Addressable or prefab-target reference to assign.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Reference(operationId, target, propertyPath, reference) end
----@param operationId string
----@param target PrefabPatchTarget
----@param active boolean
----@return PrefabPatchLuaBuilder self
+
+---Sets a target GameObject active or inactive.
+---@param operationId string Stable operation ID unique within this patch.
+---@param target PrefabPatchTarget GameObject target whose active state should change.
+---@param active boolean Desired active state.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Active(operationId, target, active) end
----@param operationId string
----@param target PrefabPatchTarget
----@return PrefabPatchLuaBuilder self
+
+---Deactivates a stock or patch-owned GameObject instead of destroying it, so
+---later patches can still resolve the same target.
+---@param operationId string Stable operation ID unique within this patch.
+---@param target PrefabPatchTarget GameObject target to suppress.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:Suppress(operationId, target) end
----@param operationId string
----@param parent PrefabPatchTarget?
----@param fragment PrefabPatchObjectFragment
----@return PrefabPatchLuaBuilder self
+
+---Adds a patch-owned GameObject hierarchy. Passing `nil` as `parent` attaches
+---the fragment directly beneath the effective prefab root.
+---@param operationId string Stable operation ID unique within this patch.
+---@param parent PrefabPatchTarget? Parent GameObject target, or nil for the prefab root.
+---@param fragment PrefabPatchObjectFragment Hierarchy fragment to create.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:AddObject(operationId, parent, fragment) end
----@param operationId string
----@param target PrefabPatchTarget
----@param component PrefabPatchComponentFragment
----@return PrefabPatchLuaBuilder self
+
+---Adds a patch-owned Component to an existing GameObject.
+---@param operationId string Stable operation ID unique within this patch.
+---@param target PrefabPatchTarget GameObject target that receives the Component.
+---@param component PrefabPatchComponentFragment Component definition to create.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:AddComponent(operationId, target, component) end
----@param operationId string
----@param target PrefabPatchTarget
----@return PrefabPatchLuaBuilder self
+
+---Removes a Component resolved by the supplied target.
+---@param operationId string Stable operation ID unique within this patch.
+---@param target PrefabPatchTarget Component target to remove.
+---@return PrefabPatchLuaBuilder self The same builder for chaining.
 function PrefabPatchLuaBuilder:RemoveComponent(operationId, target) end
----@return table manifest
+
+---Finalizes the pending manifest and returns its JSON-compatible public form
+---without registering it with the prefab-patch runtime.
+---@return JsonUserData manifest Table-like serialized prefab-patch manifest.
 function PrefabPatchLuaBuilder:Build() end
----@return table manifest
+
+---Finalizes and registers the prefab patch with Patch Manager. This method is
+---terminal and intentionally returns no CLR manifest to Lua.
 function PrefabPatchLuaBuilder:Register() end
 
----@param name string Patch-local name; ModId is prepended automatically.
+---Begins a declarative prefab patch for one stock Addressables prefab. This can
+---only be called while Patch Manager's registration phase is open.
+---@param name string Patch-local name; the current mod ID is prepended automatically.
 ---@param target string Stock prefab Addressables key.
----@return PrefabPatchLuaBuilder builder
+---@return PrefabPatchLuaBuilder builder Builder used to declare and register the patch.
+---@error Thrown outside patch registration, when `name` is invalid, or when `target` is not a string key.
 function PatchManagerCore:Prefab(name, target) end

--- a/Stubs/pm-prefabs.d.lua
+++ b/Stubs/pm-prefabs.d.lua
@@ -1,0 +1,152 @@
+---@meta
+-- Patch Manager declarative prefab-patch frontend.
+
+---@alias PrefabPatchTarget table
+---| { kind: '"Stock"', sourceSerializedFileName: string, sourcePathId: integer, objectType: string, runtimeLocator: table }
+---| { kind: '"PatchOwned"', ownerPatchId: string, objectId: string, objectType: string?, runtimeLocator: table? }
+---| { kind: '"PatchComponent"', ownerPatchId: string, componentId: string, objectType: string? }
+
+---@alias PrefabPatchReference table
+---| { kind: '"Addressable"', address: string, expectedType: string? }
+---| { kind: '"Target"', target: PrefabPatchTarget, expectedType: string? }
+
+---@class PrefabPatchValue
+---@field kind '"Boolean"'|'"Integer"'|'"Float"'|'"String"'|'"Vector2"'|'"Vector3"'|'"Vector4"'|'"Quaternion"'|'"Color"'|'"ArraySize"'|'"ManagedReference"'|'"Json"'
+---@field boolean boolean?
+---@field integer integer?
+---@field float number?
+---@field string string?
+---@field serializedType string?
+---@field x number?
+---@field y number?
+---@field z number?
+---@field w number?
+
+---@class PrefabPatchSerializedValue
+---@field propertyPath string
+---@field value PrefabPatchValue
+
+---@class PrefabPatchSerializedReference
+---@field propertyPath string
+---@field reference PrefabPatchReference
+
+---@class PrefabPatchComponentFragment
+---@field componentId string Stable ID unique within the patch.
+---@field componentType string Assembly-qualified CLR component type.
+---@field values PrefabPatchSerializedValue[]?
+---@field references PrefabPatchSerializedReference[]?
+
+---@class PrefabPatchObjectFragment
+---@field objectId string Stable ID unique within the patch.
+---@field name string?
+---@field transformType string? Assembly-qualified Transform or RectTransform type.
+---@field active boolean?
+---@field layer integer?
+---@field tag string?
+---@field isStatic boolean?
+---@field localPosition PrefabPatchValue?
+---@field localRotation PrefabPatchValue?
+---@field localScale PrefabPatchValue?
+---@field anchorMin PrefabPatchValue?
+---@field anchorMax PrefabPatchValue?
+---@field anchoredPosition PrefabPatchValue?
+---@field sizeDelta PrefabPatchValue?
+---@field pivot PrefabPatchValue?
+---@field components PrefabPatchComponentFragment[]?
+---@field children PrefabPatchObjectFragment[]?
+
+---@class PrefabPatchIdentity
+---@field address string
+---@field catalogId string
+---@field catalogHash string?
+---@field sourceBundleFileName string
+---@field sourceBundleHash string?
+---@field sourceSerializedFileName string
+---@field sourcePathId integer
+---@field assetType string
+---@field structuralDescription string
+---@field structuralFingerprint string
+
+---@class PrefabPatchLuaBuilder
+PrefabPatchLuaBuilder = {}
+
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Early() end
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Late() end
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:First() end
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Last() end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Needs(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Conflicts(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:NeedsPatch(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:ConflictsPatch(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:BeforePatch(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:AfterPatch(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Before(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:After(...) end
+---@param ... string
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Configuration(...) end
+---@param operationId string
+---@param target PrefabPatchTarget
+---@param propertyPath string
+---@param value boolean|number|string|PrefabPatchValue
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Set(operationId, target, propertyPath, value) end
+---@param operationId string
+---@param target PrefabPatchTarget
+---@param propertyPath string
+---@param reference PrefabPatchReference
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Reference(operationId, target, propertyPath, reference) end
+---@param operationId string
+---@param target PrefabPatchTarget
+---@param active boolean
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Active(operationId, target, active) end
+---@param operationId string
+---@param target PrefabPatchTarget
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:Suppress(operationId, target) end
+---@param operationId string
+---@param parent PrefabPatchTarget?
+---@param fragment PrefabPatchObjectFragment
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:AddObject(operationId, parent, fragment) end
+---@param operationId string
+---@param target PrefabPatchTarget
+---@param component PrefabPatchComponentFragment
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:AddComponent(operationId, target, component) end
+---@param operationId string
+---@param target PrefabPatchTarget
+---@return PrefabPatchLuaBuilder self
+function PrefabPatchLuaBuilder:RemoveComponent(operationId, target) end
+---@return table manifest
+function PrefabPatchLuaBuilder:Build() end
+---@return table manifest
+function PrefabPatchLuaBuilder:Register() end
+
+---@param name string Patch-local name; ModId is prepended automatically.
+---@param target PrefabPatchIdentity
+---@param modVersion string?
+---@return PrefabPatchLuaBuilder builder
+function PatchManagerCore:Prefab(name, target, modVersion) end

--- a/Stubs/pm-prefabs.d.lua
+++ b/Stubs/pm-prefabs.d.lua
@@ -2,7 +2,7 @@
 -- Patch Manager declarative prefab-patch frontend.
 
 ---@alias PrefabPatchTarget table
----| { kind: '"Stock"', sourceSerializedFileName: string, sourcePathId: integer, objectType: string, runtimeLocator: table }
+---| { kind: '"Stock"', sourceSerializedFileName: string, sourcePathId: integer|string, objectType: string, runtimeLocator: table }
 ---| { kind: '"PatchOwned"', ownerPatchId: string, objectId: string, objectType: string?, runtimeLocator: table? }
 ---| { kind: '"PatchComponent"', ownerPatchId: string, componentId: string, objectType: string? }
 
@@ -62,7 +62,7 @@
 ---@field sourceBundleFileName string
 ---@field sourceBundleHash string?
 ---@field sourceSerializedFileName string
----@field sourcePathId integer
+---@field sourcePathId integer|string Use a decimal string for 64-bit IDs outside Lua's exact numeric range.
 ---@field assetType string
 ---@field structuralDescription string
 ---@field structuralFingerprint string

--- a/Stubs/pm-prefabs.d.lua
+++ b/Stubs/pm-prefabs.d.lua
@@ -147,6 +147,5 @@ function PrefabPatchLuaBuilder:Register() end
 
 ---@param name string Patch-local name; ModId is prepended automatically.
 ---@param target PrefabPatchIdentity
----@param modVersion string?
 ---@return PrefabPatchLuaBuilder builder
-function PatchManagerCore:Prefab(name, target, modVersion) end
+function PatchManagerCore:Prefab(name, target) end

--- a/Stubs/pm-prefabs.d.lua.meta
+++ b/Stubs/pm-prefabs.d.lua.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1134442416264cf8a191c417a7642ff0


### PR DESCRIPTION
Adds support for declarative prefab patching, enabling mods to modify addressable prefabs using visual authoring, C#, and Lua. It adds new authoring APIs, integrates prefab patch plan resolution into the loading flow, and improves runtime diagnostics and cache handling. The documentation is expanded with a new guide on prefab patching.