### PR TITLE
Fix cache invalidation failing on long file paths

### DIFF
--- a/Runtime/Core/Cache/CacheManager.cs
+++ b/Runtime/Core/Cache/CacheManager.cs
@@ -115,8 +115,36 @@ namespace PatchManager.Core.Cache
 
             OpenArchives.Clear();
 
-            Directory.Delete(CACHE_DIRECTORY, true);
+            try
+            {
+                DeleteDirectory(CACHE_DIRECTORY);
+            }
+            catch (Exception e)
+            {
+                Logging.LogError($"Failed to clear the patch cache: {e}");
+            }
+
             CreateCacheFolderIfNotExists();
+        }
+
+        private static void DeleteDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
+
+            foreach (var directory in Directory.GetDirectories(path))
+            {
+                DeleteDirectory(directory);
+            }
+
+            foreach (var file in Directory.GetFiles(path))
+            {
+                File.Delete(file);
+            }
+
+            Directory.Delete(path, false);
         }
 
         /// <summary>


### PR DESCRIPTION
~~This should fix the PM bug with file paths over 250 chars~~

I Can Confirm this fixed it!!!

```
[EXC 10:11:34.678] IOException: Unknown error (0x23c2a00) : '\\?\Y:\Desktop\Kerbal Space Program 2\pm_cache'
    System.IO.FileSystem.RemoveDirectoryRecursive (System.String fullPath, Interop+Kernel32+WIN32_FIND_DATA& findData, System.Boolean topLevel) (at <816f70bc2a9c4332b0bd119906a8d40e>:0)
    System.IO.FileSystem.RemoveDirectory (System.String fullPath, System.Boolean recursive) (at <816f70bc2a9c4332b0bd119906a8d40e>:0)
    System.IO.Directory.Delete (System.String path, System.Boolean recursive) (at <816f70bc2a9c4332b0bd119906a8d40e>:0)
    PatchManager.Core.Cache.CacheManager.InvalidateCache () (at <3391bce3c2f949d79ab78107f2ffc494>:0)
    PatchManager.Core.Assets.PatchingManager.InvalidateCacheIfNeeded () (at <3391bce3c2f949d79ab78107f2ffc494>:0)
    PatchManager.Core.CoreModule.DecideCacheValidity (System.Action resolve, System.Action`1[T] reject) (at <3391bce3c2f949d79ab78107f2ffc494>:0)
    PatchManager.Core.Flow.FlowAction.DoAction (System.Action resolve, System.Action`1[T] reject) (at <3391bce3c2f949d79ab78107f2ffc494>:0)
    KSP.Game.Flow.ReduxFlowAction.DoAction (System.Action resolve, System.Action`1[T] reject) (at <3391bce3c2f949d79ab78107f2ffc494>:0)
    KSP.Game.Flow.FlowAction.Do (System.Action`1[T] resolve, System.Action`2[T1,T2] reject) (at <3391bce3c2f949d79ab78107f2ffc494>:0)
    KSP.Game.Flow.SequentialFlow.NextFlowAction () (at <3391bce3c2f949d79ab78107f2ffc494>:0)
    KSP.Game.Flow.SequentialFlow.Update () (at <3391bce3c2f949d79ab78107f2ffc494>:0)
```

Hope this helps